### PR TITLE
support for deleting multiple addresses at the same time, better warn…

### DIFF
--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -1,17 +1,20 @@
 <!DOCTYPE html>
 <html>
-	<head>
+
+<head>
 	<title>MassGIS Field Data Collection</title>
 	<meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 	<meta name="apple-mobile-web-app-capable" content="yes">
 
-<!--
+	<!--
 	<link rel="stylesheet" href="http://code.jquery.com/mobile/1.1.0/jquery.mobile-1.1.0.min.css" />
 	<script src="http://code.jquery.com/jquery-1.7.1.min.js"></script>
 	<script src="http://code.jquery.com/mobile/1.1.0/jquery.mobile-1.1.0.min.js"></script>
 -->
-	<link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.10.1/themes/ui-lightness/jquery-ui.min.css" type="text/css">
+	<link rel="stylesheet"
+		href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.10.1/themes/ui-lightness/jquery-ui.min.css"
+		type="text/css">
 	<link rel="stylesheet" href="https://code.jquery.com/mobile/1.3.1/jquery.mobile-1.3.1.min.css" />
 	<script src="js/underscore.js"></script>
 	<script src="https://code.jquery.com/jquery-1.9.1.min.js"></script>
@@ -32,22 +35,22 @@
 		//Proj4js.defs["EPSG:4326"] = "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs";
 		//proj4.defs("EPSG:3857","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs");
 	</script>
-<!--
+	<!--
 	<script src="js/OpenLayers-2.12.massgis_mft-min.js"></script>
 	<script src="js/OpenLayers-2.12.massgis_mft.js"></script>
 -->
 	<script type="text/javascript">
-var MASSGIS = {};
-//MASSGIS.proxy = "/cgi-bin/proxy_auth_fdc.cgi?url=https://wsgw.mass.gov/geoserver/wfs";
-//MASSGIS.proxy = "/cgi-bin/proxy_auth_fdc.cgi?url=http://10.202.25.161:8080/geoserver/wfs";
-//MASSGIS.proxy = "/cgi-bin/proxy_auth_fdc.cgi?url=http://10.202.26.28/geoserver/wfs";
-MASSGIS.proxy = "/cgi-bin/proxy_auth_fdc.cgi?url=https://gis-prod.digital.mass.gov/geoserver/wfs";
-// customize GPS point styling here
-MASSGIS.pointRadius = "10"; // size of point
-MASSGIS.fillColor = "#00ff00"; // color on the inside of the point
-MASSGIS.strokeColor = "#00ce18"; // color for the point outline (circumference border)
-MASSGIS.strokeWidth = "2"; // size of the point outline (circumference border width)
-MASSGIS.fillOpacity = .7; // opacity of gps point (0 = completely clear, 1 = fully opaque, .5 = half transparent)
+		var MASSGIS = {};
+		//MASSGIS.proxy = "/cgi-bin/proxy_auth_fdc.cgi?url=https://wsgw.mass.gov/geoserver/wfs";
+		//MASSGIS.proxy = "/cgi-bin/proxy_auth_fdc.cgi?url=http://10.202.25.161:8080/geoserver/wfs";
+		//MASSGIS.proxy = "/cgi-bin/proxy_auth_fdc.cgi?url=http://10.202.26.28/geoserver/wfs";
+		MASSGIS.proxy = "/cgi-bin/proxy_auth_fdc.cgi?url=https://gis-prod.digital.mass.gov/geoserver/wfs";
+		// customize GPS point styling here
+		MASSGIS.pointRadius = "10"; // size of point
+		MASSGIS.fillColor = "#00ff00"; // color on the inside of the point
+		MASSGIS.strokeColor = "#00ce18"; // color for the point outline (circumference border)
+		MASSGIS.strokeWidth = "2"; // size of the point outline (circumference border width)
+		MASSGIS.fillOpacity = .7; // opacity of gps point (0 = completely clear, 1 = fully opaque, .5 = half transparent)
 	</script>
 	<script src="js/OpenLayers-2.12.massgis_mft-min.js"></script>
 	<script src="js/massgis_mft.js"></script>
@@ -55,158 +58,170 @@ MASSGIS.fillOpacity = .7; // opacity of gps point (0 = completely clear, 1 = ful
 	<script src="js/rtree.js"></script>
 
 	<style>
-	.modalWindow {
-		width: 100%;
-		height: 100%;
-		position: absolute;
-		z-index: 150000;
-		background: white;
-		opacity: 0.7;
-	}
+		.modalWindow {
+			width: 100%;
+			height: 100%;
+			position: absolute;
+			z-index: 150000;
+			background: white;
+			opacity: 0.7;
+		}
 
-	.ui-loader{
-		z-index: 150001;
-	}
+		.ui-loader {
+			z-index: 150001;
+		}
 
-	.ui-icon-mft-sattelite {
-		background-position: 0 0;
-	}
+		.ui-icon-mft-sattelite {
+			background-position: 0 0;
+		}
 
-	.ui-icon-mgis-delete {
-		background-image: url("img/delete.png");
-		background-size: 19px;
-		background-position: 0 0;
-	}
+		.ui-icon-mgis-delete {
+			background-image: url("img/delete.png");
+			background-size: 19px;
+			background-position: 0 0;
+		}
 
-	.ui-icon-mgis-copy {
-		background-image: url("img/copy.png");
-		background-size: 19px;
-		background-position: 0 0;
-	}
+		.ui-icon-mgis-copy {
+			background-image: url("img/copy.png");
+			background-size: 19px;
+			background-position: 0 0;
+		}
 
-	.ui-icon-mgis-edit {
-		background-image: url("img/edit.png");
-		background-size: 19px;
-		background-position: 0 0;
-	}
+		.ui-icon-mgis-edit {
+			background-image: url("img/edit.png");
+			background-size: 19px;
+			background-position: 0 0;
+		}
 
-	.ui-listview-filter {
-		margin: 0;
-	}
-	.ui-mobile #map img {
-		max-width: 256px;
-	}
+		.ui-listview-filter {
+			margin: 0;
+		}
 
-	.ui-autocomplete {
-		z-index: 100000;
-	}
+		.ui-mobile #map img {
+			max-width: 256px;
+		}
 
-	.ui-autocomplete.ui-widget-content {
-		background: #eee 50% top repeat-x;
-	}
+		.ui-autocomplete {
+			z-index: 100000;
+		}
 
-	.half-frame {
-		width: 50%;
-		height: 100%;
-		position: relative;
-		display: inline-block;
-		float: left;
-		overflow: hidden;
-	}
+		.ui-autocomplete.ui-widget-content {
+			background: #eee 50% top repeat-x;
+		}
 
-	#map {
-		//height: 400px;
-	}
-	#gps_controls {
-		position: absolute;
-		right: 40px;
-		top: 5px;
-		z-index:100000;
-	}
-	#layer_switcher {
-		position: absolute;
-		right: 40px;
-		top: 140px;
-		z-index:1000;
-	}
-	#settings {
-		position: absolute;
-		left: 40px;
-		bottom: 20px;
-		z-index:100000;
-	}
-	#zoom_buttons {
-		position: absolute;
-		left: 40px;
-		top: 5px;
-		z-index:100000;
-	}
-	#zoom_buttons .ui-icon-minus {
-		top: 36%;
-	}
-	#zoom_buttons .ui-icon-plus {
-		top: 36%;
-	}
-	.ui-icon.ui-icon-shadow.ui-icon-mft-sattelite {
-		background-image: url("img/sattelite_icon.png");
-		width: 81px;
-		height: 48px;
-		left: 20%;
-		bottom: 20%;
-	}
-	#layer_switcher .ui-btn-text {
-		color : #fff !important;
-		text-shadow:
-		-1px -1px 0 #222,
-		1px -1px 0 #222,
-		-1px 1px 0 #222,
-		1px 1px 0 #222 !important;
-	}
-	.custom_button {
-		height : 32px !important;
-		line-height : 12px !important;
-		margin : .2em 0 !important;
-	}
+		.half-frame {
+			width: 50%;
+			height: 100%;
+			position: relative;
+			display: inline-block;
+			float: left;
+			overflow: hidden;
+		}
 
+		#map {
+			//height: 400px;
+		}
+
+		#gps_controls {
+			position: absolute;
+			right: 40px;
+			top: 5px;
+			z-index: 100000;
+		}
+
+		#layer_switcher {
+			position: absolute;
+			right: 40px;
+			top: 140px;
+			z-index: 1000;
+		}
+
+		#settings {
+			position: absolute;
+			left: 40px;
+			bottom: 20px;
+			z-index: 100000;
+		}
+
+		#zoom_buttons {
+			position: absolute;
+			left: 40px;
+			top: 5px;
+			z-index: 100000;
+		}
+
+		#zoom_buttons .ui-icon-minus {
+			top: 36%;
+		}
+
+		#zoom_buttons .ui-icon-plus {
+			top: 36%;
+		}
+
+		.ui-icon.ui-icon-shadow.ui-icon-mft-sattelite {
+			background-image: url("img/sattelite_icon.png");
+			width: 81px;
+			height: 48px;
+			left: 20%;
+			bottom: 20%;
+		}
+
+		#layer_switcher .ui-btn-text {
+			color: #fff !important;
+			text-shadow:
+				-1px -1px 0 #222,
+				1px -1px 0 #222,
+				-1px 1px 0 #222,
+				1px 1px 0 #222 !important;
+		}
+
+		.custom_button {
+			height: 32px !important;
+			line-height: 12px !important;
+			margin: .2em 0 !important;
+		}
 	</style>
 	<script>
-	// stop page from "bouncing"
-	document.ontouchmove = function(e){
-		e.preventDefault();
-	}
-	$(document).ready(function() {
-		$('#linked_addrs,#addr_list').each(function(idx, elt) {
-			elt.ontouchmove = function(e) {
-				e.stopPropagation();
-			};
+		// stop page from "bouncing"
+		document.ontouchmove = function (e) {
+			e.preventDefault();
+		}
+		$(document).ready(function () {
+			$('#linked_addrs,#addr_list').each(function (idx, elt) {
+				elt.ontouchmove = function (e) {
+					e.stopPropagation();
+				};
+			});
 		});
-	});
-	var fixgeometry = function() {
-		scroll(0, 0);
+		var fixgeometry = function () {
+			scroll(0, 0);
 
-		$(["linked_addrs","addr_list"]).each(function(idx, eltId) {
-			/* Calculate the geometry that our content area should take */
-			var section = $('#' + eltId);
-			var buttons = $('#' + eltId + "_buttons");
-			var parent_height = section.parent().height();
-			section.height(parent_height - buttons.height());
-			$('#' + eltId + " > div").height(parent_height - buttons.height() - $('#' + eltId + " > header").height());
-		});
-	};
+			$(["linked_addrs", "addr_list"]).each(function (idx, eltId) {
+				/* Calculate the geometry that our content area should take */
+				var section = $('#' + eltId);
+				var buttons = $('#' + eltId + "_buttons");
+				var parent_height = section.parent().height();
+				section.height(parent_height - buttons.height());
+				$('#' + eltId + " > div").height(parent_height - buttons.height() - $('#' + eltId + " > header").height());
+			});
+		};
 
-</script>
+	</script>
 
 </head>
+
 <body class="dont_scroll">
 	<div data-role="page" id="mappage">
 		<div id="edit_popup" data-role="popup" class="ui-content" style="padding:20px">
 			<h2>Edit Address</h2>
 			<div>
 				<div style="float:left; width:15%; padding-left: 10px">
-					<input type="text" id="edit_full_number_standardized" maxlength="30" data-mini="true" placeholder="addr #" />
+					<input type="text" id="edit_full_number_standardized" maxlength="30" data-mini="true"
+						placeholder="addr #" />
 				</div>
 				<div style="float:left; width:55%; padding-left:10px">
-					<input type="text" id="edit_street_name" maxlength="80" data-mini="true" placeholder="street name" />
+					<input type="text" id="edit_street_name" maxlength="80" data-mini="true"
+						placeholder="street name" />
 				</div>
 				<div style="float:left; width:22%; padding-left:10px">
 					<input type="text" id="edit_REL_LOC" maxlength="80" data-mini="true" placeholder="location" />
@@ -221,11 +236,14 @@ MASSGIS.fillOpacity = .7; // opacity of gps point (0 = completely clear, 1 = ful
 					<input type="text" id="edit_building_name" maxlength="50" data-mini="true" placeholder="building" />
 				</div>
 				<div style="clear: both; float:left; width:95%; padding-left:10px">
-					<input type="text" id="edit_last_edit_comments" maxlength="200" data-mini="true" placeholder="notes" />
+					<input type="text" id="edit_last_edit_comments" maxlength="200" data-mini="true"
+						placeholder="notes" />
 				</div>
 				<div style="clear: both">
-					<a href="#" data-rel="back" data-role="button" data-theme="c" data-icon="delete" class="ui-btn-right">Cancel</a>
-					<a href="#" data-rel="back" data-role="button" data-theme="c" data-icon="check" class="ui-btn-right">Save</a>
+					<a href="#" data-rel="back" data-role="button" data-theme="c" data-icon="delete"
+						class="ui-btn-right">Cancel</a>
+					<a href="#" data-rel="back" data-role="button" data-theme="c" data-icon="check"
+						class="ui-btn-right">Save</a>
 				</div>
 			</div>
 		</div>
@@ -240,9 +258,12 @@ MASSGIS.fillOpacity = .7; // opacity of gps point (0 = completely clear, 1 = ful
 						and you would like to ignore it for the purposes of
 						address standardization in this town, please tap "Ignore This Point"
 					</div>
-					<a href="#" data-rel="back" data-role="button" data-theme="c" data-icon="delete" class="ui-btn-right">Delete This Point</a>
-					<a href="#" data-rel="back" data-role="button" data-theme="c" data-icon="minus" class="ui-btn-right">Ignore This Point</a>
-					<a href="#" data-rel="back" data-role="button" data-theme="c" data-icon="back" class="ui-btn-right">Do Nothing (Go Back)</a>
+					<a href="#" data-rel="back" data-role="button" data-theme="c" data-icon="delete"
+						class="ui-btn-right">Delete This Point</a>
+					<a href="#" data-rel="back" data-role="button" data-theme="c" data-icon="minus"
+						class="ui-btn-right">Ignore This Point</a>
+					<a href="#" data-rel="back" data-role="button" data-theme="c" data-icon="back"
+						class="ui-btn-right">Do Nothing (Go Back)</a>
 				</div>
 			</div>
 		</div>
@@ -250,11 +271,30 @@ MASSGIS.fillOpacity = .7; // opacity of gps point (0 = completely clear, 1 = ful
 			<div>
 				<div style="clear: both">
 					<div style="margin-bottom: 10px">
-						Are you sure you want to delete this address record?
+						Are you sure you want to perform this delete?
 					</div>
 					<div style="white-space: nowrap">
-						<a href="#" data-rel="back" data-role="button" data-theme="c" data-icon="delete" class="ui-btn-right">Delete This Address</a>
-						<a href="#" data-rel="back" data-role="button" data-theme="c" data-icon="back" class="ui-btn-right">Do Nothing (Go Back)</a>
+						<a href="#" data-rel="back" data-role="button" data-theme="c" data-icon="delete"
+							class="ui-btn-right">Delete This Address</a>
+						<a href="#" data-rel="back" data-role="button" data-theme="c" data-icon="back"
+							class="ui-btn-right">Do Nothing (Go Back)</a>
+					</div>
+				</div>
+			</div>
+		</div>
+		<div id="confirm_add_multi_part_popup" data-role="popup" class="ui-content" style="padding:20px;">
+			<div>
+				<div style="clear: both">
+					<div style="margin-bottom: 10px">
+						WARNING: You are about to create a new part to the selected preexisting address point.<br />
+						This will <b>not</b> flag the new part as a new structure for internal review.<br />
+						If you wish to create a new standalone point, please go back and clear your selection.
+					</div>
+					<div style="white-space: nowrap">
+						<a href="#" data-rel="back" data-role="button" data-theme="c" data-icon="plus"
+							class="ui-btn-right">Add new Part</a>
+						<a href="#" data-rel="back" data-role="button" data-theme="c" data-icon="back"
+							class="ui-btn-right">Do Nothing (Go Back)</a>
 					</div>
 				</div>
 			</div>
@@ -265,7 +305,8 @@ MASSGIS.fillOpacity = .7; // opacity of gps point (0 = completely clear, 1 = ful
 				<div id="gps_controls"></div>
 				<div id="layer_switcher">
 					<div data-role="fieldcontain">
-						<a href="#" data-iconpos="bottom" data-role="button" data-theme="b" data-icon="mft-sattelite">MassGIS</a>
+						<a href="#" data-iconpos="bottom" data-role="button" data-theme="b"
+							data-icon="mft-sattelite">MassGIS</a>
 					</div>
 				</div>
 				<div id="settings">
@@ -276,8 +317,10 @@ MASSGIS.fillOpacity = .7; // opacity of gps point (0 = completely clear, 1 = ful
 				<div id="zoom_buttons">
 					<div data-role="fieldcontain">
 						<fieldset data-role="controlgroup">
-							<input type="button" data-theme="b" data-iconpos="top" data-icon="plus" id="zoom_in" value="&nbsp;"/>
-							<input type="button" data-theme="b" data-iconpos="bottom" data-icon="minus" id="zoom_out" value="&nbsp;"/>
+							<input type="button" data-theme="b" data-iconpos="top" data-icon="plus" id="zoom_in"
+								value="&nbsp;" />
+							<input type="button" data-theme="b" data-iconpos="bottom" data-icon="minus" id="zoom_out"
+								value="&nbsp;" />
 						</fieldset>
 					</div>
 				</div>
@@ -286,7 +329,9 @@ MASSGIS.fillOpacity = .7; // opacity of gps point (0 = completely clear, 1 = ful
 				<div style="height: 100%">
 					<div style="height:50%;">
 						<section class="panel_box" id="linked_addrs">
-							<header><h2>Linked Addresses</h2></header>
+							<header>
+								<h2>Linked Addresses</h2>
+							</header>
 							<div style="overflow: auto;">
 								<ul data-role="listview" data-inset="true">
 								</ul>
@@ -303,10 +348,13 @@ MASSGIS.fillOpacity = .7; // opacity of gps point (0 = completely clear, 1 = ful
 					</div>
 					<div style="height:50%;">
 						<section class="panel_box" id="addr_query" style="display:none">
-							<header><h2>Search for Addresses</h2></header>
+							<header>
+								<h2>Search for Addresses</h2>
+							</header>
 							<div id="addr_query_inputs" style="height:84px;">
 								<div style="float:left; width:15%; padding-left: 10px">
-									<input type="text" id="full_number_standardized" data-mini="true" placeholder="addr #" />
+									<input type="text" id="full_number_standardized" data-mini="true"
+										placeholder="addr #" />
 								</div>
 								<div style="float:left; width:55%; padding-left: 10px">
 									<input type="text" id="street_name" data-mini="true" placeholder="street name" />
@@ -324,7 +372,8 @@ MASSGIS.fillOpacity = .7; // opacity of gps point (0 = completely clear, 1 = ful
 									<input type="text" id="building_name" data-mini="true" placeholder="building" />
 								</div>
 								<div style="float:right; width:22%; padding-right:10px">
-									<a class="custom_button" data-theme="b" data-role="button" id="select_all_addr">Select all</a>
+									<a class="custom_button" data-theme="b" data-role="button"
+										id="select_all_addr">Select all</a>
 								</div>
 							</div>
 							<div id="addr_query_res" style="overflow: auto;">
@@ -334,7 +383,9 @@ MASSGIS.fillOpacity = .7; // opacity of gps point (0 = completely clear, 1 = ful
 							</div>
 						</section>
 						<section class="panel_box" id="addr_list">
-							<header><h2>Address List</h2></header>
+							<header>
+								<h2>Address List</h2>
+							</header>
 							<div style="overflow: auto;">
 								<ul data-role="listview" data-inset="true">
 
@@ -367,7 +418,7 @@ MASSGIS.fillOpacity = .7; // opacity of gps point (0 = completely clear, 1 = ful
 		</div>
 		<div data-role="content" id="pickAddrPageContent"">
 		</div>
-		<div data-role="footer" style="max-height: 40%; overflow: auto">
+		<div data-role=" footer" style="max-height: 40%; overflow: auto">
 			<a href="#" data-role="button" data-icon="back" onclick="history.back()">Back</a>
 		</div>
 	</div>
@@ -376,403 +427,407 @@ MASSGIS.fillOpacity = .7; // opacity of gps point (0 = completely clear, 1 = ful
 		<div data-role="content">
 			<!--<div id="qunit"></div>-->
 			<div data-role="fieldcontain">
-				<a href="#mappage" style="position: absolute; right: 40px;" data-role="button" data-theme="c" data-icon="arrow-l">Back to Map</a>
+				<a href="#mappage" style="position: absolute; right: 40px;" data-role="button" data-theme="c"
+					data-icon="arrow-l">Back to Map</a>
 			</div>
-			<h3 style="text-align: center" ><span id="settings_maf"></span> Addresses Currently Stored</h3>
-			<h3 style="text-align: center" ><span id="settings_addrs"></span> Address Points Currently Stored</h3>
+			<h3 style="text-align: center"><span id="settings_maf"></span> Addresses Currently Stored</h3>
+			<h3 style="text-align: center"><span id="settings_addrs"></span> Address Points Currently Stored</h3>
 
 			<div data-role="fieldcontain" style="text-align: center;padding-top:30px">
-				<label style="width: 24%; vertical-align: middle" for="msag_community" class="select"><h3>MSAG Community:</h3></label>
+				<label style="width: 24%; vertical-align: middle" for="msag_community" class="select">
+					<h3>MSAG Community:</h3>
+				</label>
 				<select id="msag_community">
 					<option value="">Select an MSAG Community...</option>
-						<option value='1'>ABINGTON</option>
-						<option value='2'>ACTON</option>
-						<option value='3'>ACUSHNET</option>
-						<option value='4'>ADAMS</option>
-						<option value='5'>AGAWAM</option>
-						<option value='6'>ALFORD</option>
-						<option value='7'>AMESBURY</option>
-						<option value='8'>AMHERST</option>
-						<option value='9'>ANDOVER</option>
-						<option value='10'>AQUINNAH</option>
-						<option value='11'>ARLINGTON</option>
-						<option value='12'>ASHBURNHAM</option>
-						<option value='13'>ASHBY</option>
-						<option value='14'>ASHFIELD</option>
-						<option value='15'>ASHLAND</option>
-						<option value='16'>ATHOL</option>
-						<option value='17'>ATTLEBORO</option>
-						<option value='18'>AUBURN</option>
-						<option value='19'>AVON</option>
-						<option value='20'>AYER</option>
-						<option value='21'>BARNSTABLE</option>
-						<option value='22'>BARRE</option>
-						<option value='23'>BECKET</option>
-						<option value='24'>BEDFORD</option>
-						<option value='25'>BELCHERTOWN</option>
-						<option value='26'>BELLINGHAM</option>
-						<option value='27'>BELMONT</option>
-						<option value='28'>BERKLEY</option>
-						<option value='29'>BERLIN</option>
-						<option value='30'>BERNARDSTON</option>
-						<option value='31'>BEVERLY</option>
-						<option value='32'>BILLERICA</option>
-						<option value='33'>BLACKSTONE</option>
-						<option value='34'>BLANDFORD</option>
-						<option value='35'>BOLTON</option>
-						<option value='36'>BONDSVILLE</option>
-						<option value='37'>BOSTON</option>
-						<option value='38'>BOURNE</option>
-						<option value='39'>BOXBORO</option>
-						<option value='40'>BOXFORD</option>
-						<option value='41'>BOYLSTON</option>
-						<option value='42'>BRAINTREE</option>
-						<option value='43'>BREWSTER</option>
-						<option value='44'>BRIDGEWATER</option>
-						<option value='45'>BRIGHTON</option>
-						<option value='46'>BRIMFIELD</option>
-						<option value='47'>BROCKTON</option>
-						<option value='48'>BROOKFIELD</option>
-						<option value='49'>BROOKLINE</option>
-						<option value='50'>BUCKLAND</option>
-						<option value='51'>BURLINGTON</option>
-						<option value='52'>CAMBRIDGE</option>
-						<option value='53'>CANTON</option>
-						<option value='54'>CARLISLE</option>
-						<option value='55'>CARVER</option>
-						<option value='56'>CENTERVILLE</option>
-						<option value='57'>CHARLEMONT</option>
-						<option value='58'>CHARLESTOWN</option>
-						<option value='59'>CHARLTON</option>
-						<option value='60'>CHATHAM</option>
-						<option value='61'>CHELMSFORD</option>
-						<option value='62'>CHELSEA</option>
-						<option value='63'>CHESHIRE</option>
-						<option value='64'>CHESTER</option>
-						<option value='65'>CHESTERFIELD</option>
-						<option value='66'>CHICOPEE</option>
-						<option value='67'>CHILMARK</option>
-						<option value='68'>CLARKSBURG</option>
-						<option value='69'>CLINTON</option>
-						<option value='70'>COHASSET</option>
-						<option value='71'>COLRAIN</option>
-						<option value='72'>CONCORD</option>
-						<option value='73'>CONWAY</option>
-						<option value='74'>COTUIT</option>
-						<option value='75'>CUMMINGTON</option>
-						<option value='76'>DALTON</option>
-						<option value='77'>DANVERS</option>
-						<option value='78'>DARTMOUTH</option>
-						<option value='79'>DEDHAM</option>
-						<option value='80'>DEERFIELD</option>
-						<option value='81'>DENNIS</option>
-						<option value='82'>DENNISPORT</option>
-						<option value='83'>DEVENS</option>
-						<option value='83'>DEVENS</option>
-						<option value='83'>DEVENS</option>
-						<option value='84'>DIGHTON</option>
-						<option value='85'>DORCHESTER</option>
-						<option value='86'>DOUGLAS</option>
-						<option value='87'>DOVER</option>
-						<option value='88'>DRACUT</option>
-						<option value='89'>DUDLEY</option>
-						<option value='90'>DUNSTABLE</option>
-						<option value='91'>DUXBURY</option>
-						<option value='92'>EAST BOSTON</option>
-						<option value='93'>EAST BRIDGEWATER</option>
-						<option value='94'>EAST BROOKFIELD</option>
-						<option value='95'>EAST LONGMEADOW</option>
-						<option value='96'>EASTHAM</option>
-						<option value='97'>EASTHAMPTON</option>
-						<option value='98'>EASTON</option>
-						<option value='99'>EDGARTOWN</option>
-						<option value='100'>EGREMONT</option>
-						<option value='101'>ERVING</option>
-						<option value='102'>ESSEX</option>
-						<option value='103'>EVERETT</option>
-						<option value='104'>FAIRHAVEN</option>
-						<option value='105'>FALL RIVER</option>
-						<option value='106'>FALMOUTH</option>
-						<option value='107'>FITCHBURG</option>
-						<option value='108'>FLORENCE</option>
-						<option value='109'>FLORIDA</option>
-						<option value='110'>FOXBOROUGH</option>
-						<option value='111'>FRAMINGHAM</option>
-						<option value='112'>FRANKLIN</option>
-						<option value='113'>FREETOWN</option>
-						<option value='114'>GARDNER</option>
-						<option value='115'>GEORGETOWN</option>
-						<option value='116'>GILL</option>
-						<option value='117'>GLOUCESTER</option>
-						<option value='118'>GOSHEN</option>
-						<option value='119'>GOSNOLD</option>
-						<option value='120'>GRAFTON</option>
-						<option value='121'>GRANBY</option>
-						<option value='122'>GRANVILLE</option>
-						<option value='123'>GREAT BARRINGTON</option>
-						<option value='124'>GREENFIELD</option>
-						<option value='125'>GROTON</option>
-						<option value='126'>GROVELAND</option>
-						<option value='127'>HADLEY</option>
-						<option value='128'>HALIFAX</option>
-						<option value='129'>HAMILTON</option>
-						<option value='130'>HAMPDEN</option>
-						<option value='131'>HANCOCK</option>
-						<option value='132'>HANOVER</option>
-						<option value='133'>HANSON</option>
-						<option value='134'>HARDWICK</option>
-						<option value='135'>HARVARD</option>
-						<option value='136'>HARWICH</option>
-						<option value='137'>HATFIELD</option>
-						<option value='138'>HAVERHILL</option>
-						<option value='139'>HAWLEY</option>
-						<option value='140'>HEATH</option>
-						<option value='141'>HINGHAM</option>
-						<option value='142'>HINSDALE</option>
-						<option value='143'>HOLBROOK</option>
-						<option value='144'>HOLDEN</option>
-						<option value='145'>HOLLAND</option>
-						<option value='146'>HOLLISTON</option>
-						<option value='147'>HOLYOKE</option>
-						<option value='148'>HOPEDALE</option>
-						<option value='149'>HOPKINTON</option>
-						<option value='150'>HUBBARDSTON</option>
-						<option value='151'>HUDSON</option>
-						<option value='152'>HULL</option>
-						<option value='153'>HUNTINGTON</option>
-						<option value='154'>HYANNIS</option>
-						<option value='155'>HYDE PARK</option>
-						<option value='156'>INDIAN ORCHARD</option>
-						<option value='157'>IPSWICH</option>
-						<option value='158'>JAMAICA PLAIN</option>
-						<option value='159'>KINGSTON</option>
-						<option value='160'>LAKEVILLE</option>
-						<option value='161'>LANCASTER</option>
-						<option value='162'>LANESBORO</option>
-						<option value='163'>LAWRENCE</option>
-						<option value='164'>LEE</option>
-						<option value='165'>LEEDS</option>
-						<option value='166'>LEICESTER</option>
-						<option value='167'>LENOX</option>
-						<option value='168'>LEOMINSTER</option>
-						<option value='169'>LEVERETT</option>
-						<option value='170'>LEXINGTON</option>
-						<option value='171'>LEYDEN</option>
-						<option value='172'>LINCOLN</option>
-						<option value='173'>LITTLETON</option>
-						<option value='174'>LONGMEADOW</option>
-						<option value='175'>LOWELL</option>
-						<option value='176'>LUDLOW</option>
-						<option value='177'>LUNENBURG</option>
-						<option value='178'>LYNN</option>
-						<option value='179'>LYNNFIELD</option>
-						<option value='180'>MALDEN</option>
-						<option value='181'>MANCHESTER</option>
-						<option value='182'>MANSFIELD</option>
-						<option value='183'>MARBLEHEAD</option>
-						<option value='184'>MARION</option>
-						<option value='185'>MARLBOROUGH</option>
-						<option value='186'>MARSHFIELD</option>
-						<option value='187'>MARSTONS MILLS</option>
-						<option value='188'>MASHPEE</option>
-						<option value='189'>MATTAPAN</option>
-						<option value='190'>MATTAPOISETT</option>
-						<option value='191'>MAYNARD</option>
-						<option value='192'>MEDFIELD</option>
-						<option value='193'>MEDFORD</option>
-						<option value='194'>MEDWAY</option>
-						<option value='195'>MELROSE</option>
-						<option value='196'>MENDON</option>
-						<option value='197'>MERRIMAC</option>
-						<option value='198'>METHUEN</option>
-						<option value='199'>MIDDLEBORO</option>
-						<option value='200'>MIDDLEFIELD</option>
-						<option value='201'>MIDDLETON</option>
-						<option value='202'>MILFORD</option>
-						<option value='203'>MILLBURY</option>
-						<option value='204'>MILLIS</option>
-						<option value='205'>MILLVILLE</option>
-						<option value='206'>MILTON</option>
-						<option value='207'>MONROE</option>
-						<option value='208'>MONSON</option>
-						<option value='209'>MONTAGUE</option>
-						<option value='210'>MONTEREY</option>
-						<option value='211'>MONTGOMERY</option>
-						<option value='212'>MOUNT WASHINGTON</option>
-						<option value='213'>NAHANT</option>
-						<option value='214'>NANTUCKET</option>
-						<option value='215'>NATICK</option>
-						<option value='216'>NEEDHAM</option>
-						<option value='217'>NEW ASHFORD</option>
-						<option value='218'>NEW BEDFORD</option>
-						<option value='219'>NEW BRAINTREE</option>
-						<option value='220'>NEW MARLBORO</option>
-						<option value='221'>NEW SALEM</option>
-						<option value='222'>NEWBURY</option>
-						<option value='223'>NEWBURYPORT</option>
-						<option value='224'>NEWTON</option>
-						<option value='225'>NORFOLK</option>
-						<option value='226'>NORTH ADAMS</option>
-						<option value='227'>NORTH ANDOVER</option>
-						<option value='228'>NORTH ATTLEBORO</option>
-						<option value='229'>NORTH BROOKFIELD</option>
-						<option value='230'>NORTH READING</option>
-						<option value='231'>NORTHAMPTON</option>
-						<option value='232'>NORTHBOROUGH</option>
-						<option value='233'>NORTHBRIDGE</option>
-						<option value='234'>NORTHFIELD</option>
-						<option value='235'>NORTON</option>
-						<option value='236'>NORWELL</option>
-						<option value='237'>NORWOOD</option>
-						<option value='238'>OAK BLUFFS</option>
-						<option value='239'>OAKHAM</option>
-						<option value='240'>ORANGE</option>
-						<option value='241'>ORLEANS</option>
-						<option value='242'>OSTERVILLE</option>
-						<option value='243'>OTIS</option>
-						<option value='244'>OXFORD</option>
-						<option value='245'>PALMER</option>
-						<option value='246'>PAXTON</option>
-						<option value='247'>PEABODY</option>
-						<option value='248'>PELHAM</option>
-						<option value='249'>PEMBROKE</option>
-						<option value='250'>PEPPERELL</option>
-						<option value='251'>PERU</option>
-						<option value='252'>PETERSHAM</option>
-						<option value='253'>PHILLIPSTON</option>
-						<option value='254'>PITTSFIELD</option>
-						<option value='255'>PLAINFIELD</option>
-						<option value='256'>PLAINVILLE</option>
-						<option value='257'>PLYMOUTH</option>
-						<option value='258'>PLYMPTON</option>
-						<option value='259'>PRINCETON</option>
-						<option value='260'>PROVINCETOWN</option>
-						<option value='261'>QUINCY</option>
-						<option value='262'>RANDOLPH</option>
-						<option value='263'>RAYNHAM</option>
-						<option value='264'>READING</option>
-						<option value='265'>REHOBOTH</option>
-						<option value='266'>REVERE</option>
-						<option value='267'>RICHMOND</option>
-						<option value='268'>ROCHESTER</option>
-						<option value='269'>ROCKLAND</option>
-						<option value='270'>ROCKPORT</option>
-						<option value='271'>ROSLINDALE</option>
-						<option value='272'>ROWE</option>
-						<option value='273'>ROWLEY</option>
-						<option value='274'>ROXBURY</option>
-						<option value='275'>ROYALSTON</option>
-						<option value='276'>RUSSELL</option>
-						<option value='277'>RUTLAND</option>
-						<option value='278'>SALEM</option>
-						<option value='279'>SALISBURY</option>
-						<option value='280'>SANDISFIELD</option>
-						<option value='281'>SANDWICH</option>
-						<option value='282'>SAUGUS</option>
-						<option value='283'>SAVOY</option>
-						<option value='284'>SCITUATE</option>
-						<option value='285'>SEEKONK</option>
-						<option value='286'>SHARON</option>
-						<option value='287'>SHEFFIELD</option>
-						<option value='288'>SHELBURNE</option>
-						<option value='289'>SHERBORN</option>
-						<option value='290'>SHIRLEY</option>
-						<option value='291'>SHREWSBURY</option>
-						<option value='292'>SHUTESBURY</option>
-						<option value='293'>SIASCONSET</option>
-						<option value='294'>SOMERSET</option>
-						<option value='295'>SOMERVILLE</option>
-						<option value='296'>SOUTH BOSTON</option>
-						<option value='380'>SOUTH DEERFIELD</option>
-						<option value='297'>SOUTH DENNIS</option>
-						<option value='298'>SOUTH HADLEY</option>
-						<option value='299'>SOUTHAMPTON</option>
-						<option value='300'>SOUTHBOROUGH</option>
-						<option value='301'>SOUTHBRIDGE</option>
-						<option value='302'>SOUTHWICK</option>
-						<option value='303'>SPENCER</option>
-						<option value='304'>SPRINGFIELD</option>
-						<option value='305'>STERLING</option>
-						<option value='306'>STOCKBRIDGE</option>
-						<option value='307'>STONEHAM</option>
-						<option value='308'>STOUGHTON</option>
-						<option value='309'>STOW</option>
-						<option value='310'>STURBRIDGE</option>
-						<option value='311'>SUDBURY</option>
-						<option value='312'>SUNDERLAND</option>
-						<option value='313'>SUTTON</option>
-						<option value='314'>SWAMPSCOTT</option>
-						<option value='315'>SWANSEA</option>
-						<option value='316'>TAUNTON</option>
-						<option value='317'>TEMPLETON</option>
-						<option value='318'>TEWKSBURY</option>
-						<option value='319'>THORNDIKE</option>
-						<option value='320'>THREE RIVERS</option>
-						<option value='321'>TISBURY</option>
-						<option value='322'>TOLLAND</option>
-						<option value='323'>TOPSFIELD</option>
-						<option value='324'>TOWNSEND</option>
-						<option value='325'>TRURO</option>
-						<option value='326'>TYNGSBORO</option>
-						<option value='327'>TYRINGHAM</option>
-						<option value='328'>UPTON</option>
-						<option value='329'>UXBRIDGE</option>
-						<option value='330'>WAKEFIELD</option>
-						<option value='331'>WALES</option>
-						<option value='332'>WALPOLE</option>
-						<option value='333'>WALTHAM</option>
-						<option value='334'>WARE</option>
-						<option value='335'>WAREHAM</option>
-						<option value='336'>WARREN</option>
-						<option value='337'>WARWICK</option>
-						<option value='338'>WASHINGTON</option>
-						<option value='339'>WATERTOWN</option>
-						<option value='340'>WAYLAND</option>
-						<option value='341'>WEBSTER</option>
-						<option value='342'>WELLESLEY</option>
-						<option value='343'>WELLFLEET</option>
-						<option value='344'>WENDELL</option>
-						<option value='345'>WENHAM</option>
-						<option value='346'>WEST BARNSTABLE</option>
-						<option value='347'>WEST BOYLSTON</option>
-						<option value='348'>WEST BRIDGEWATER</option>
-						<option value='349'>WEST BROOKFIELD</option>
-						<option value='350'>WEST DENNIS</option>
-						<option value='351'>WEST NEWBURY</option>
-						<option value='352'>WEST ROXBURY</option>
-						<option value='353'>WEST SPRINGFIELD</option>
-						<option value='354'>WEST STOCKBRIDGE</option>
-						<option value='355'>WEST TISBURY</option>
-						<option value='356'>WESTBOROUGH</option>
-						<option value='357'>WESTFIELD</option>
-						<option value='358'>WESTFORD</option>
-						<option value='359'>WESTHAMPTON</option>
-						<option value='360'>WESTMINSTER</option>
-						<option value='361'>WESTON</option>
-						<option value='362'>WESTPORT</option>
-						<option value='363'>WESTWOOD</option>
-						<option value='364'>WEYMOUTH</option>
-						<option value='365'>WHATELY</option>
-						<option value='366'>WHITMAN</option>
-						<option value='367'>WILBRAHAM</option>
-						<option value='368'>WILLIAMSBURG</option>
-						<option value='369'>WILLIAMSTOWN</option>
-						<option value='370'>WILMINGTON</option>
-						<option value='371'>WINCHENDON</option>
-						<option value='372'>WINCHESTER</option>
-						<option value='373'>WINDSOR</option>
-						<option value='374'>WINTHROP</option>
-						<option value='375'>WOBURN</option>
-						<option value='376'>WORCESTER</option>
-						<option value='377'>WORTHINGTON</option>
-						<option value='378'>WRENTHAM</option>
-						<option value='379'>YARMOUTH</option>
+					<option value='1'>ABINGTON</option>
+					<option value='2'>ACTON</option>
+					<option value='3'>ACUSHNET</option>
+					<option value='4'>ADAMS</option>
+					<option value='5'>AGAWAM</option>
+					<option value='6'>ALFORD</option>
+					<option value='7'>AMESBURY</option>
+					<option value='8'>AMHERST</option>
+					<option value='9'>ANDOVER</option>
+					<option value='10'>AQUINNAH</option>
+					<option value='11'>ARLINGTON</option>
+					<option value='12'>ASHBURNHAM</option>
+					<option value='13'>ASHBY</option>
+					<option value='14'>ASHFIELD</option>
+					<option value='15'>ASHLAND</option>
+					<option value='16'>ATHOL</option>
+					<option value='17'>ATTLEBORO</option>
+					<option value='18'>AUBURN</option>
+					<option value='19'>AVON</option>
+					<option value='20'>AYER</option>
+					<option value='21'>BARNSTABLE</option>
+					<option value='22'>BARRE</option>
+					<option value='23'>BECKET</option>
+					<option value='24'>BEDFORD</option>
+					<option value='25'>BELCHERTOWN</option>
+					<option value='26'>BELLINGHAM</option>
+					<option value='27'>BELMONT</option>
+					<option value='28'>BERKLEY</option>
+					<option value='29'>BERLIN</option>
+					<option value='30'>BERNARDSTON</option>
+					<option value='31'>BEVERLY</option>
+					<option value='32'>BILLERICA</option>
+					<option value='33'>BLACKSTONE</option>
+					<option value='34'>BLANDFORD</option>
+					<option value='35'>BOLTON</option>
+					<option value='36'>BONDSVILLE</option>
+					<option value='37'>BOSTON</option>
+					<option value='38'>BOURNE</option>
+					<option value='39'>BOXBORO</option>
+					<option value='40'>BOXFORD</option>
+					<option value='41'>BOYLSTON</option>
+					<option value='42'>BRAINTREE</option>
+					<option value='43'>BREWSTER</option>
+					<option value='44'>BRIDGEWATER</option>
+					<option value='45'>BRIGHTON</option>
+					<option value='46'>BRIMFIELD</option>
+					<option value='47'>BROCKTON</option>
+					<option value='48'>BROOKFIELD</option>
+					<option value='49'>BROOKLINE</option>
+					<option value='50'>BUCKLAND</option>
+					<option value='51'>BURLINGTON</option>
+					<option value='52'>CAMBRIDGE</option>
+					<option value='53'>CANTON</option>
+					<option value='54'>CARLISLE</option>
+					<option value='55'>CARVER</option>
+					<option value='56'>CENTERVILLE</option>
+					<option value='57'>CHARLEMONT</option>
+					<option value='58'>CHARLESTOWN</option>
+					<option value='59'>CHARLTON</option>
+					<option value='60'>CHATHAM</option>
+					<option value='61'>CHELMSFORD</option>
+					<option value='62'>CHELSEA</option>
+					<option value='63'>CHESHIRE</option>
+					<option value='64'>CHESTER</option>
+					<option value='65'>CHESTERFIELD</option>
+					<option value='66'>CHICOPEE</option>
+					<option value='67'>CHILMARK</option>
+					<option value='68'>CLARKSBURG</option>
+					<option value='69'>CLINTON</option>
+					<option value='70'>COHASSET</option>
+					<option value='71'>COLRAIN</option>
+					<option value='72'>CONCORD</option>
+					<option value='73'>CONWAY</option>
+					<option value='74'>COTUIT</option>
+					<option value='75'>CUMMINGTON</option>
+					<option value='76'>DALTON</option>
+					<option value='77'>DANVERS</option>
+					<option value='78'>DARTMOUTH</option>
+					<option value='79'>DEDHAM</option>
+					<option value='80'>DEERFIELD</option>
+					<option value='81'>DENNIS</option>
+					<option value='82'>DENNISPORT</option>
+					<option value='83'>DEVENS</option>
+					<option value='83'>DEVENS</option>
+					<option value='83'>DEVENS</option>
+					<option value='84'>DIGHTON</option>
+					<option value='85'>DORCHESTER</option>
+					<option value='86'>DOUGLAS</option>
+					<option value='87'>DOVER</option>
+					<option value='88'>DRACUT</option>
+					<option value='89'>DUDLEY</option>
+					<option value='90'>DUNSTABLE</option>
+					<option value='91'>DUXBURY</option>
+					<option value='92'>EAST BOSTON</option>
+					<option value='93'>EAST BRIDGEWATER</option>
+					<option value='94'>EAST BROOKFIELD</option>
+					<option value='95'>EAST LONGMEADOW</option>
+					<option value='96'>EASTHAM</option>
+					<option value='97'>EASTHAMPTON</option>
+					<option value='98'>EASTON</option>
+					<option value='99'>EDGARTOWN</option>
+					<option value='100'>EGREMONT</option>
+					<option value='101'>ERVING</option>
+					<option value='102'>ESSEX</option>
+					<option value='103'>EVERETT</option>
+					<option value='104'>FAIRHAVEN</option>
+					<option value='105'>FALL RIVER</option>
+					<option value='106'>FALMOUTH</option>
+					<option value='107'>FITCHBURG</option>
+					<option value='108'>FLORENCE</option>
+					<option value='109'>FLORIDA</option>
+					<option value='110'>FOXBOROUGH</option>
+					<option value='111'>FRAMINGHAM</option>
+					<option value='112'>FRANKLIN</option>
+					<option value='113'>FREETOWN</option>
+					<option value='114'>GARDNER</option>
+					<option value='115'>GEORGETOWN</option>
+					<option value='116'>GILL</option>
+					<option value='117'>GLOUCESTER</option>
+					<option value='118'>GOSHEN</option>
+					<option value='119'>GOSNOLD</option>
+					<option value='120'>GRAFTON</option>
+					<option value='121'>GRANBY</option>
+					<option value='122'>GRANVILLE</option>
+					<option value='123'>GREAT BARRINGTON</option>
+					<option value='124'>GREENFIELD</option>
+					<option value='125'>GROTON</option>
+					<option value='126'>GROVELAND</option>
+					<option value='127'>HADLEY</option>
+					<option value='128'>HALIFAX</option>
+					<option value='129'>HAMILTON</option>
+					<option value='130'>HAMPDEN</option>
+					<option value='131'>HANCOCK</option>
+					<option value='132'>HANOVER</option>
+					<option value='133'>HANSON</option>
+					<option value='134'>HARDWICK</option>
+					<option value='135'>HARVARD</option>
+					<option value='136'>HARWICH</option>
+					<option value='137'>HATFIELD</option>
+					<option value='138'>HAVERHILL</option>
+					<option value='139'>HAWLEY</option>
+					<option value='140'>HEATH</option>
+					<option value='141'>HINGHAM</option>
+					<option value='142'>HINSDALE</option>
+					<option value='143'>HOLBROOK</option>
+					<option value='144'>HOLDEN</option>
+					<option value='145'>HOLLAND</option>
+					<option value='146'>HOLLISTON</option>
+					<option value='147'>HOLYOKE</option>
+					<option value='148'>HOPEDALE</option>
+					<option value='149'>HOPKINTON</option>
+					<option value='150'>HUBBARDSTON</option>
+					<option value='151'>HUDSON</option>
+					<option value='152'>HULL</option>
+					<option value='153'>HUNTINGTON</option>
+					<option value='154'>HYANNIS</option>
+					<option value='155'>HYDE PARK</option>
+					<option value='156'>INDIAN ORCHARD</option>
+					<option value='157'>IPSWICH</option>
+					<option value='158'>JAMAICA PLAIN</option>
+					<option value='159'>KINGSTON</option>
+					<option value='160'>LAKEVILLE</option>
+					<option value='161'>LANCASTER</option>
+					<option value='162'>LANESBORO</option>
+					<option value='163'>LAWRENCE</option>
+					<option value='164'>LEE</option>
+					<option value='165'>LEEDS</option>
+					<option value='166'>LEICESTER</option>
+					<option value='167'>LENOX</option>
+					<option value='168'>LEOMINSTER</option>
+					<option value='169'>LEVERETT</option>
+					<option value='170'>LEXINGTON</option>
+					<option value='171'>LEYDEN</option>
+					<option value='172'>LINCOLN</option>
+					<option value='173'>LITTLETON</option>
+					<option value='174'>LONGMEADOW</option>
+					<option value='175'>LOWELL</option>
+					<option value='176'>LUDLOW</option>
+					<option value='177'>LUNENBURG</option>
+					<option value='178'>LYNN</option>
+					<option value='179'>LYNNFIELD</option>
+					<option value='180'>MALDEN</option>
+					<option value='181'>MANCHESTER</option>
+					<option value='182'>MANSFIELD</option>
+					<option value='183'>MARBLEHEAD</option>
+					<option value='184'>MARION</option>
+					<option value='185'>MARLBOROUGH</option>
+					<option value='186'>MARSHFIELD</option>
+					<option value='187'>MARSTONS MILLS</option>
+					<option value='188'>MASHPEE</option>
+					<option value='189'>MATTAPAN</option>
+					<option value='190'>MATTAPOISETT</option>
+					<option value='191'>MAYNARD</option>
+					<option value='192'>MEDFIELD</option>
+					<option value='193'>MEDFORD</option>
+					<option value='194'>MEDWAY</option>
+					<option value='195'>MELROSE</option>
+					<option value='196'>MENDON</option>
+					<option value='197'>MERRIMAC</option>
+					<option value='198'>METHUEN</option>
+					<option value='199'>MIDDLEBORO</option>
+					<option value='200'>MIDDLEFIELD</option>
+					<option value='201'>MIDDLETON</option>
+					<option value='202'>MILFORD</option>
+					<option value='203'>MILLBURY</option>
+					<option value='204'>MILLIS</option>
+					<option value='205'>MILLVILLE</option>
+					<option value='206'>MILTON</option>
+					<option value='207'>MONROE</option>
+					<option value='208'>MONSON</option>
+					<option value='209'>MONTAGUE</option>
+					<option value='210'>MONTEREY</option>
+					<option value='211'>MONTGOMERY</option>
+					<option value='212'>MOUNT WASHINGTON</option>
+					<option value='213'>NAHANT</option>
+					<option value='214'>NANTUCKET</option>
+					<option value='215'>NATICK</option>
+					<option value='216'>NEEDHAM</option>
+					<option value='217'>NEW ASHFORD</option>
+					<option value='218'>NEW BEDFORD</option>
+					<option value='219'>NEW BRAINTREE</option>
+					<option value='220'>NEW MARLBORO</option>
+					<option value='221'>NEW SALEM</option>
+					<option value='222'>NEWBURY</option>
+					<option value='223'>NEWBURYPORT</option>
+					<option value='224'>NEWTON</option>
+					<option value='225'>NORFOLK</option>
+					<option value='226'>NORTH ADAMS</option>
+					<option value='227'>NORTH ANDOVER</option>
+					<option value='228'>NORTH ATTLEBORO</option>
+					<option value='229'>NORTH BROOKFIELD</option>
+					<option value='230'>NORTH READING</option>
+					<option value='231'>NORTHAMPTON</option>
+					<option value='232'>NORTHBOROUGH</option>
+					<option value='233'>NORTHBRIDGE</option>
+					<option value='234'>NORTHFIELD</option>
+					<option value='235'>NORTON</option>
+					<option value='236'>NORWELL</option>
+					<option value='237'>NORWOOD</option>
+					<option value='238'>OAK BLUFFS</option>
+					<option value='239'>OAKHAM</option>
+					<option value='240'>ORANGE</option>
+					<option value='241'>ORLEANS</option>
+					<option value='242'>OSTERVILLE</option>
+					<option value='243'>OTIS</option>
+					<option value='244'>OXFORD</option>
+					<option value='245'>PALMER</option>
+					<option value='246'>PAXTON</option>
+					<option value='247'>PEABODY</option>
+					<option value='248'>PELHAM</option>
+					<option value='249'>PEMBROKE</option>
+					<option value='250'>PEPPERELL</option>
+					<option value='251'>PERU</option>
+					<option value='252'>PETERSHAM</option>
+					<option value='253'>PHILLIPSTON</option>
+					<option value='254'>PITTSFIELD</option>
+					<option value='255'>PLAINFIELD</option>
+					<option value='256'>PLAINVILLE</option>
+					<option value='257'>PLYMOUTH</option>
+					<option value='258'>PLYMPTON</option>
+					<option value='259'>PRINCETON</option>
+					<option value='260'>PROVINCETOWN</option>
+					<option value='261'>QUINCY</option>
+					<option value='262'>RANDOLPH</option>
+					<option value='263'>RAYNHAM</option>
+					<option value='264'>READING</option>
+					<option value='265'>REHOBOTH</option>
+					<option value='266'>REVERE</option>
+					<option value='267'>RICHMOND</option>
+					<option value='268'>ROCHESTER</option>
+					<option value='269'>ROCKLAND</option>
+					<option value='270'>ROCKPORT</option>
+					<option value='271'>ROSLINDALE</option>
+					<option value='272'>ROWE</option>
+					<option value='273'>ROWLEY</option>
+					<option value='274'>ROXBURY</option>
+					<option value='275'>ROYALSTON</option>
+					<option value='276'>RUSSELL</option>
+					<option value='277'>RUTLAND</option>
+					<option value='278'>SALEM</option>
+					<option value='279'>SALISBURY</option>
+					<option value='280'>SANDISFIELD</option>
+					<option value='281'>SANDWICH</option>
+					<option value='282'>SAUGUS</option>
+					<option value='283'>SAVOY</option>
+					<option value='284'>SCITUATE</option>
+					<option value='285'>SEEKONK</option>
+					<option value='286'>SHARON</option>
+					<option value='287'>SHEFFIELD</option>
+					<option value='288'>SHELBURNE</option>
+					<option value='289'>SHERBORN</option>
+					<option value='290'>SHIRLEY</option>
+					<option value='291'>SHREWSBURY</option>
+					<option value='292'>SHUTESBURY</option>
+					<option value='293'>SIASCONSET</option>
+					<option value='294'>SOMERSET</option>
+					<option value='295'>SOMERVILLE</option>
+					<option value='296'>SOUTH BOSTON</option>
+					<option value='380'>SOUTH DEERFIELD</option>
+					<option value='297'>SOUTH DENNIS</option>
+					<option value='298'>SOUTH HADLEY</option>
+					<option value='299'>SOUTHAMPTON</option>
+					<option value='300'>SOUTHBOROUGH</option>
+					<option value='301'>SOUTHBRIDGE</option>
+					<option value='302'>SOUTHWICK</option>
+					<option value='303'>SPENCER</option>
+					<option value='304'>SPRINGFIELD</option>
+					<option value='305'>STERLING</option>
+					<option value='306'>STOCKBRIDGE</option>
+					<option value='307'>STONEHAM</option>
+					<option value='308'>STOUGHTON</option>
+					<option value='309'>STOW</option>
+					<option value='310'>STURBRIDGE</option>
+					<option value='311'>SUDBURY</option>
+					<option value='312'>SUNDERLAND</option>
+					<option value='313'>SUTTON</option>
+					<option value='314'>SWAMPSCOTT</option>
+					<option value='315'>SWANSEA</option>
+					<option value='316'>TAUNTON</option>
+					<option value='317'>TEMPLETON</option>
+					<option value='318'>TEWKSBURY</option>
+					<option value='319'>THORNDIKE</option>
+					<option value='320'>THREE RIVERS</option>
+					<option value='321'>TISBURY</option>
+					<option value='322'>TOLLAND</option>
+					<option value='323'>TOPSFIELD</option>
+					<option value='324'>TOWNSEND</option>
+					<option value='325'>TRURO</option>
+					<option value='326'>TYNGSBORO</option>
+					<option value='327'>TYRINGHAM</option>
+					<option value='328'>UPTON</option>
+					<option value='329'>UXBRIDGE</option>
+					<option value='330'>WAKEFIELD</option>
+					<option value='331'>WALES</option>
+					<option value='332'>WALPOLE</option>
+					<option value='333'>WALTHAM</option>
+					<option value='334'>WARE</option>
+					<option value='335'>WAREHAM</option>
+					<option value='336'>WARREN</option>
+					<option value='337'>WARWICK</option>
+					<option value='338'>WASHINGTON</option>
+					<option value='339'>WATERTOWN</option>
+					<option value='340'>WAYLAND</option>
+					<option value='341'>WEBSTER</option>
+					<option value='342'>WELLESLEY</option>
+					<option value='343'>WELLFLEET</option>
+					<option value='344'>WENDELL</option>
+					<option value='345'>WENHAM</option>
+					<option value='346'>WEST BARNSTABLE</option>
+					<option value='347'>WEST BOYLSTON</option>
+					<option value='348'>WEST BRIDGEWATER</option>
+					<option value='349'>WEST BROOKFIELD</option>
+					<option value='350'>WEST DENNIS</option>
+					<option value='351'>WEST NEWBURY</option>
+					<option value='352'>WEST ROXBURY</option>
+					<option value='353'>WEST SPRINGFIELD</option>
+					<option value='354'>WEST STOCKBRIDGE</option>
+					<option value='355'>WEST TISBURY</option>
+					<option value='356'>WESTBOROUGH</option>
+					<option value='357'>WESTFIELD</option>
+					<option value='358'>WESTFORD</option>
+					<option value='359'>WESTHAMPTON</option>
+					<option value='360'>WESTMINSTER</option>
+					<option value='361'>WESTON</option>
+					<option value='362'>WESTPORT</option>
+					<option value='363'>WESTWOOD</option>
+					<option value='364'>WEYMOUTH</option>
+					<option value='365'>WHATELY</option>
+					<option value='366'>WHITMAN</option>
+					<option value='367'>WILBRAHAM</option>
+					<option value='368'>WILLIAMSBURG</option>
+					<option value='369'>WILLIAMSTOWN</option>
+					<option value='370'>WILMINGTON</option>
+					<option value='371'>WINCHENDON</option>
+					<option value='372'>WINCHESTER</option>
+					<option value='373'>WINDSOR</option>
+					<option value='374'>WINTHROP</option>
+					<option value='375'>WOBURN</option>
+					<option value='376'>WORCESTER</option>
+					<option value='377'>WORTHINGTON</option>
+					<option value='378'>WRENTHAM</option>
+					<option value='379'>YARMOUTH</option>
 				</select>
 			</div>
-			<input type="button" disabled="disabled" id="settings_syncnow" value="Download Records in Selected Community" /> <br/>
-			<input type="button" id="settings_clear" value="Clear Records from This Device" /> <br/>
-			<input type="button" id="settings_sync_tiles" value="Sync tiles in current map area" /> <br/>
-			<input type="button" id="settings_upload" value="Submit My Updates" /> <br/>
+			<input type="button" disabled="disabled" id="settings_syncnow"
+				value="Download Records in Selected Community" /> <br />
+			<input type="button" id="settings_clear" value="Clear Records from This Device" /> <br />
+			<input type="button" id="settings_sync_tiles" value="Sync tiles in current map area" /> <br />
+			<input type="button" id="settings_upload" value="Submit My Updates" /> <br />
 		</div>
 
 		<div id="login_popup" data-role="popup" class="ui-content" style="padding:20px">
@@ -780,13 +835,16 @@ MASSGIS.fillOpacity = .7; // opacity of gps point (0 = completely clear, 1 = ful
 			<div>
 				<div style="float:left; width:100%">
 					<form id="save_email_form">
-						<input type="text" id="login_username" maxlength="30" data-mini="true" placeholder="email address" />
+						<input type="text" id="login_username" maxlength="30" data-mini="true"
+							placeholder="email address" />
 					</form>
 				</div>
 			</div>
 			<div style="clear: both">
-				<a href="#" data-rel="back" data-role="button" data-theme="c" data-icon="delete" class="ui-btn-right">Cancel</a>
-				<a href="#" data-rel="back" data-role="button" data-theme="c" data-icon="check" class="ui-btn-right">OK</a>
+				<a href="#" data-rel="back" data-role="button" data-theme="c" data-icon="delete"
+					class="ui-btn-right">Cancel</a>
+				<a href="#" data-rel="back" data-role="button" data-theme="c" data-icon="check"
+					class="ui-btn-right">OK</a>
 			</div>
 		</div>
 	</div>
@@ -833,4 +891,5 @@ MASSGIS.fillOpacity = .7; // opacity of gps point (0 = completely clear, 1 = ful
 	</li>
 	{{/if}}
 </script>
+
 </html>

--- a/htdocs/js/massgis_mft.js
+++ b/htdocs/js/massgis_mft.js
@@ -1,4 +1,4 @@
-OpenLayers.Layer.Vector.prototype.moveTo = function(bounds, zoomChanged, dragging) {
+OpenLayers.Layer.Vector.prototype.moveTo = function (bounds, zoomChanged, dragging) {
 	OpenLayers.Layer.prototype.moveTo.apply(this, arguments);
 
 	var coordSysUnchanged = true;
@@ -41,9 +41,9 @@ OpenLayers.Layer.Vector.prototype.moveTo = function(bounds, zoomChanged, draggin
 		var feature;
 		if (this.spatialIndex) {
 			this.renderer.clear();
-			var searchRect = {x:bounds.left, y:bounds.bottom, w: bounds.getWidth(), h: bounds.getHeight()};
+			var searchRect = { x: bounds.left, y: bounds.bottom, w: bounds.getWidth(), h: bounds.getHeight() };
 			var featuresToDraw = this.spatialIndex.search(searchRect);
-			for(var i=0, len=featuresToDraw.length; i<len; i++) {
+			for (var i = 0, len = featuresToDraw.length; i < len; i++) {
 				this.renderer.locked = (i !== (len - 1));
 				feature = featuresToDraw[i];
 				if (feature.geometry.bounds.intersectsBounds(bounds)) {
@@ -51,7 +51,7 @@ OpenLayers.Layer.Vector.prototype.moveTo = function(bounds, zoomChanged, draggin
 				}
 			}
 		} else {
-			for(var i=0, len=this.features.length; i<len; i++) {
+			for (var i = 0, len = this.features.length; i < len; i++) {
 				this.renderer.locked = (i !== (len - 1));
 				feature = this.features[i];
 				this.drawFeature(feature);
@@ -66,11 +66,11 @@ var tiles = {};
 OpenLayers.Layer.IndexedVector = OpenLayers.Class(OpenLayers.Layer.Vector, {
 	CLASS_NAME: "OpenLayers.Layer.IndexedVector",
 
-	reindex : function() {
+	reindex: function () {
 		var that = this;
-		this.indexes && $.each(this.indexes, function(attrname, oldIndex) {
+		this.indexes && $.each(this.indexes, function (attrname, oldIndex) {
 			var index = {};
-			$.each(that.features, function(idx, feature) {
+			$.each(that.features, function (idx, feature) {
 				if (feature.attributes && feature.attributes[attrname]) {
 					if (index[feature.attributes[attrname]]) {
 						index[feature.attributes[attrname]].push(feature);
@@ -82,21 +82,21 @@ OpenLayers.Layer.IndexedVector = OpenLayers.Class(OpenLayers.Layer.Vector, {
 			that.indexes[attrname] = index;
 		});
 	},
-	initialize: function(name, options) {
+	initialize: function (name, options) {
 		OpenLayers.Layer.Vector.prototype.initialize.apply(this, arguments);
 
-		this.events.register("featuresadded",this,function(obj) {
+		this.events.register("featuresadded", this, function (obj) {
 			//console.log("features added to layer " + this.name + ".  Re-indexing layer");
 			this.reindex();
 		});
 
-		this.events.register("featuresremoved",this,function(obj) {
+		this.events.register("featuresremoved", this, function (obj) {
 			//console.log("features removed from layer " + this.name + ".  Re-indexing layer");
 			this.reindex();
 		});
 	},
 
-	getFeaturesByAttribute: function(attribute, value) {
+	getFeaturesByAttribute: function (attribute, value) {
 		// search using index
 		if (this.indexes && this.indexes[attribute]) {
 			var list = this.indexes[attribute][value];
@@ -106,7 +106,7 @@ OpenLayers.Layer.IndexedVector = OpenLayers.Class(OpenLayers.Layer.Vector, {
 				return this.indexes[attribute][value];
 			}
 		}
-		return OpenLayers.Layer.Vector.prototype.getFeaturesByAttribute.apply(this,[attribute, value]);
+		return OpenLayers.Layer.Vector.prototype.getFeaturesByAttribute.apply(this, [attribute, value]);
 	}
 });
 
@@ -115,349 +115,349 @@ OpenLayers.Layer.SpatialIndexedVector = OpenLayers.Class(OpenLayers.Layer.Indexe
 
 	spatialIndex: null,
 
-	reindex: function() {
-		OpenLayers.Layer.IndexedVector.prototype.reindex.apply(this,[]);
+	reindex: function () {
+		OpenLayers.Layer.IndexedVector.prototype.reindex.apply(this, []);
 		this.spatialIndex = new RTree();
 		var that = this;
-		$.each(this.features, function(idx, feature) {
+		$.each(this.features, function (idx, feature) {
 			feature.geometry && feature.geometry.calculateBounds();
 			if (feature.geometry && feature.geometry.getBounds()) {
 				var bounds = feature.geometry.getBounds();
-				that.spatialIndex.insert({x:bounds.left - 1, y:bounds.bottom - 1, w:bounds.getWidth() + 1, h:bounds.getHeight() + 1}, feature);
+				that.spatialIndex.insert({ x: bounds.left - 1, y: bounds.bottom - 1, w: bounds.getWidth() + 1, h: bounds.getHeight() + 1 }, feature);
 			}
 		});
 	},
-	initialize: function(name, options) {
+	initialize: function (name, options) {
 		OpenLayers.Layer.IndexedVector.prototype.initialize.apply(this, arguments);
 		this.spatialIndex = new RTree();
-		this.events.register("featureadded", this, function(obj) {
+		this.events.register("featureadded", this, function (obj) {
 			if (obj.feature.geometry) {
 				obj.feature.geometry.calculateBounds();
 				var bounds = obj.feature.geometry.getBounds();
-				bounds && this.spatialIndex.insert({x:bounds.left - 1, y:bounds.bottom - 1, w:bounds.getWidth() + 1, h:bounds.getHeight() + 1}, obj.feature);
+				bounds && this.spatialIndex.insert({ x: bounds.left - 1, y: bounds.bottom - 1, w: bounds.getWidth() + 1, h: bounds.getHeight() + 1 }, obj.feature);
 			}
 		});
 
-		this.events.register("featuremodified", this, function(obj) {
+		this.events.register("featuremodified", this, function (obj) {
 			if (obj.feature.geometry) {
 				obj.feature.geometry.calculateBounds();
 				var bounds = obj.feature.geometry.getBounds();
-				bounds && this.spatialIndex.remove({x:bounds.left - 1, y:bounds.bottom - 1, w:bounds.getWidth() + 1, h:bounds.getHeight() + 1}, obj.feature);
-				bounds && this.spatialIndex.insert({x:bounds.left - 1, y:bounds.bottom - 1, w:bounds.getWidth() + 1, h:bounds.getHeight() + 1}, obj.feature);
+				bounds && this.spatialIndex.remove({ x: bounds.left - 1, y: bounds.bottom - 1, w: bounds.getWidth() + 1, h: bounds.getHeight() + 1 }, obj.feature);
+				bounds && this.spatialIndex.insert({ x: bounds.left - 1, y: bounds.bottom - 1, w: bounds.getWidth() + 1, h: bounds.getHeight() + 1 }, obj.feature);
 			}
 		});
 
-		this.events.register("featureremoved", this, function(obj) {
+		this.events.register("featureremoved", this, function (obj) {
 			if (obj.feature.geometry) {
 				obj.feature.geometry.calculateBounds();
 				var bounds = obj.feature.geometry.getBounds();
-				bounds && this.spatialIndex.remove({x:bounds.left - 1, y:bounds.bottom - 1, w:bounds.getWidth() + 1, h:bounds.getHeight() + 1}, obj.feature);
+				bounds && this.spatialIndex.remove({ x: bounds.left - 1, y: bounds.bottom - 1, w: bounds.getWidth() + 1, h: bounds.getHeight() + 1 }, obj.feature);
 			}
 		});
 	}
 });
 
 
-(function() {
+(function () {
 
-MASSGIS.init_app = false;
-MASSGIS.init_data = false;
-MASSGIS.addr_candidates = {};
-MASSGIS.site_candidates = {};
-MASSGIS.active_point = false;
-MASSGIS.pageinit = false;
-MASSGIS.addressListMode = 'street';
-MASSGIS.cachedTiles = {};
-MASSGIS.undoStack = {};
-MASSGIS.username;
-MASSGIS.addressQueryResults = [];
-MASSGIS.mapTypes = ['Road','Ortho 2013-14','Ortho 2014-15','Blank'];
-MASSGIS.mapType = MASSGIS.mapTypes[0];
+	MASSGIS.init_app = false;
+	MASSGIS.init_data = false;
+	MASSGIS.addr_candidates = {};
+	MASSGIS.site_candidates = {};
+	MASSGIS.active_point = false;
+	MASSGIS.pageinit = false;
+	MASSGIS.addressListMode = 'street';
+	MASSGIS.cachedTiles = {};
+	MASSGIS.undoStack = {};
+	MASSGIS.username;
+	MASSGIS.addressQueryResults = [];
+	MASSGIS.mapTypes = ['Road', 'Ortho 2013-14', 'Ortho 2014-15', 'Blank'];
+	MASSGIS.mapType = MASSGIS.mapTypes[0];
 
 
-$(document).on("pageinit", function(evt) {
-	if (MASSGIS.pageinit) return;
+	$(document).on("pageinit", function (evt) {
+		if (MASSGIS.pageinit) return;
 
-	MASSGIS.pageinit = true;
+		MASSGIS.pageinit = true;
 
-	// allow some navbar buttons to NOT stay pressed
-	$(document).on('tap', function(e){
-		$('.noActivePersist').removeClass($.mobile.activeBtnClass);
-	});
+		// allow some navbar buttons to NOT stay pressed
+		$(document).on('tap', function (e) {
+			$('.noActivePersist').removeClass($.mobile.activeBtnClass);
+		});
 
-	$(window).bind("orientationchange resize pageshow", fixgeometry);
-	$('#mappage').on('pageshow',function(evt) {
-		if (!MASSGIS.init_app) {
-			MASSGIS.init_map();
-			MASSGIS.init_ui();
-			jQuery("#gps_controls").gps_map_controls({
-				map: MASSGIS.map,
-				pointRadius: MASSGIS.pointRadius,
-				fillColor: MASSGIS.fillColor,
-				strokeColor: MASSGIS.strokeColor,
-				strokeWidth: MASSGIS.strokeWidth,
-				fillOpacity: MASSGIS.fillOpacity
-			});
-			MASSGIS.init_app = true;
-		}
-		if (!MASSGIS.init_data) {
-			MASSGIS.loadCachedTiles();
-			MASSGIS.init_datastores();
-		}
-	});
+		$(window).bind("orientationchange resize pageshow", fixgeometry);
+		$('#mappage').on('pageshow', function (evt) {
+			if (!MASSGIS.init_app) {
+				MASSGIS.init_map();
+				MASSGIS.init_ui();
+				jQuery("#gps_controls").gps_map_controls({
+					map: MASSGIS.map,
+					pointRadius: MASSGIS.pointRadius,
+					fillColor: MASSGIS.fillColor,
+					strokeColor: MASSGIS.strokeColor,
+					strokeWidth: MASSGIS.strokeWidth,
+					fillOpacity: MASSGIS.fillOpacity
+				});
+				MASSGIS.init_app = true;
+			}
+			if (!MASSGIS.init_data) {
+				MASSGIS.loadCachedTiles();
+				MASSGIS.init_datastores();
+			}
+		});
 
-	$(document).on('pagechange',function(evt, options) {
-		if ($.mobile.activePage.attr('id') !== 'mappage' && !MASSGIS.init) {
-			//location.href="/fdc";
-			//return;
-		}
-	});
-});
-
-MASSGIS.loadCachedTiles = function() {
-	//$.mobile.showPageLoadingMsg('b','Loading Stored Map Images (This may take a minute)','true');
-	MASSGIS.showModalMessage('Loading Stored Map Images (This may take a minute)');
-	var tileDb = openDatabase('tiledb','1.0','tiledb',1 * 1024 * 1024);
-	tileDb.transaction(function(tx) {
-		tx.executeSql("select * from osm",[],function(tx,results) {
-			for (var i = 0 ; i < results.rows.length; i++) {
-				MASSGIS.cachedTiles[results.rows.item(i).url.substring(9)] = results.rows.item(i).uri;
+		$(document).on('pagechange', function (evt, options) {
+			if ($.mobile.activePage.attr('id') !== 'mappage' && !MASSGIS.init) {
+				//location.href="/fdc";
+				//return;
 			}
 		});
 	});
-};
 
-MASSGIS.config = {
-	// the tolerance (in pixels) around a point to search when tapping the map
-	"tapTolerance" : 20
-};
+	MASSGIS.loadCachedTiles = function () {
+		//$.mobile.showPageLoadingMsg('b','Loading Stored Map Images (This may take a minute)','true');
+		MASSGIS.showModalMessage('Loading Stored Map Images (This may take a minute)');
+		var tileDb = openDatabase('tiledb', '1.0', 'tiledb', 1 * 1024 * 1024);
+		tileDb.transaction(function (tx) {
+			tx.executeSql("select * from osm", [], function (tx, results) {
+				for (var i = 0; i < results.rows.length; i++) {
+					MASSGIS.cachedTiles[results.rows.item(i).url.substring(9)] = results.rows.item(i).uri;
+				}
+			});
+		});
+	};
 
-MASSGIS.init_ui = function() {
-	$('#search_street').on("click",function() {
-		$('#addr_query').css('display','none');
-		$('#addr_list').css('display','block');
-		MASSGIS.addressListMode = 'street';
-		MASSGIS.renderAddressList();
-	});
+	MASSGIS.config = {
+		// the tolerance (in pixels) around a point to search when tapping the map
+		"tapTolerance": 20
+	};
 
-	$('#search_proximity').on("click",function() {
-		$('#addr_query').css('display','none');
-		$('#addr_list').css('display','block');
-		MASSGIS.addressListMode = 'proximity';
+	MASSGIS.init_ui = function () {
+		$('#search_street').on("click", function () {
+			$('#addr_query').css('display', 'none');
+			$('#addr_list').css('display', 'block');
+			MASSGIS.addressListMode = 'street';
+			MASSGIS.renderAddressList();
+		});
 
-		// Pull back everything w/i the map bbox.
-		// Keep track of map center for sorting later on.
-		var lonLat;
-		var gps = jQuery("#gps_controls").gps_map_controls('getLastPosition');
+		$('#search_proximity').on("click", function () {
+			$('#addr_query').css('display', 'none');
+			$('#addr_list').css('display', 'block');
+			MASSGIS.addressListMode = 'proximity';
 
-		lonLat = MASSGIS.map.getCenter();
+			// Pull back everything w/i the map bbox.
+			// Keep track of map center for sorting later on.
+			var lonLat;
+			var gps = jQuery("#gps_controls").gps_map_controls('getLastPosition');
 
-		var bbox = MASSGIS.map.getExtent();
-		var searchRect = {
-			x : bbox.left
-			,y : bbox.bottom
-			,w : bbox.right - bbox.left
-			,h : bbox.top - bbox.bottom
-		};
-		var potentialSelAddrs = MASSGIS.lyr_address_points.spatialIndex.search(searchRect);
-		while (potentialSelAddrs.length > 200) {
-			console.log("shrinking bbox because we had too many results: " + potentialSelAddrs.length);
-			bbox = bbox.scale(.75);
-			searchRect = {
-				x : bbox.left
-				,y : bbox.bottom
-				,w : bbox.right - bbox.left
-				,h : bbox.top - bbox.bottom
+			lonLat = MASSGIS.map.getCenter();
+
+			var bbox = MASSGIS.map.getExtent();
+			var searchRect = {
+				x: bbox.left
+				, y: bbox.bottom
+				, w: bbox.right - bbox.left
+				, h: bbox.top - bbox.bottom
 			};
-			potentialSelAddrs = MASSGIS.lyr_address_points.spatialIndex.search(searchRect);
-		}
-		console.log("shrunk bbox to garner # results: " + potentialSelAddrs.length);
+			var potentialSelAddrs = MASSGIS.lyr_address_points.spatialIndex.search(searchRect);
+			while (potentialSelAddrs.length > 200) {
+				console.log("shrinking bbox because we had too many results: " + potentialSelAddrs.length);
+				bbox = bbox.scale(.75);
+				searchRect = {
+					x: bbox.left
+					, y: bbox.bottom
+					, w: bbox.right - bbox.left
+					, h: bbox.top - bbox.bottom
+				};
+				potentialSelAddrs = MASSGIS.lyr_address_points.spatialIndex.search(searchRect);
+			}
+			console.log("shrunk bbox to garner # results: " + potentialSelAddrs.length);
 
-		// Refine the results by looking at each distance from the center and put each hit
-		// into a hash by distance.  It's possible, but unlikely, for > 1 addr to be equidistant
-		// from the center point.
-		var addrsByDistance = {};
-		if (potentialSelAddrs.length !== 0) {
-			var centerPoint = new OpenLayers.Geometry.Point(lonLat.lon,lonLat.lat);
-			$.each(potentialSelAddrs, function(idx, mpt) {
-				var pt = mpt.geometry.getCentroid();
-				if (pt) {
-					var d = pt.distanceTo(centerPoint);
-					if (!addrsByDistance[d]) {
-						addrsByDistance[d] = [];
+			// Refine the results by looking at each distance from the center and put each hit
+			// into a hash by distance.  It's possible, but unlikely, for > 1 addr to be equidistant
+			// from the center point.
+			var addrsByDistance = {};
+			if (potentialSelAddrs.length !== 0) {
+				var centerPoint = new OpenLayers.Geometry.Point(lonLat.lon, lonLat.lat);
+				$.each(potentialSelAddrs, function (idx, mpt) {
+					var pt = mpt.geometry.getCentroid();
+					if (pt) {
+						var d = pt.distanceTo(centerPoint);
+						if (!addrsByDistance[d]) {
+							addrsByDistance[d] = [];
+						}
+						addrsByDistance[d].push(mpt.attributes.address_point_id);
 					}
-					addrsByDistance[d].push(mpt.attributes.address_point_id);
-				}
-			});
-		}
+				});
+			}
 
-		// Sort the distances.
-		var distances = [];
-		for (d in addrsByDistance) {
-			distances.push(d);
-		}
-		distances.sort(function(a,b){return a-b});
+			// Sort the distances.
+			var distances = [];
+			for (d in addrsByDistance) {
+				distances.push(d);
+			}
+			distances.sort(function (a, b) { return a - b });
 
-		// Pull back the MAF hits ordered by distance.
-		var sortedAddrsByDistance = [];
-		for (var i = 0; i < distances.length; i++) {
-			var a = addrsByDistance[distances[i]];
-			for (var j = 0; j < a.length; j++) {
-				var f = MASSGIS.lyr_maf.getFeaturesByAttribute("address_point_id",a[j]);
-				for (var j = 0; j < f.length; j++) {
-					if (f[j].attributes.address_status == 'DELETED') {
-						continue;
+			// Pull back the MAF hits ordered by distance.
+			var sortedAddrsByDistance = [];
+			for (var i = 0; i < distances.length; i++) {
+				var a = addrsByDistance[distances[i]];
+				for (var j = 0; j < a.length; j++) {
+					var f = MASSGIS.lyr_maf.getFeaturesByAttribute("address_point_id", a[j]);
+					for (var j = 0; j < f.length; j++) {
+						if (f[j].attributes.address_status == 'DELETED') {
+							continue;
+						}
+						sortedAddrsByDistance.push(f[j]);
 					}
-					sortedAddrsByDistance.push(f[j]);
 				}
 			}
-		}
-		MASSGIS.lyr_maf_constrained.removeFeatures(MASSGIS.lyr_maf_constrained.features);
-		MASSGIS.lyr_maf_constrained.addFeatures(sortedAddrsByDistance);
+			MASSGIS.lyr_maf_constrained.removeFeatures(MASSGIS.lyr_maf_constrained.features);
+			MASSGIS.lyr_maf_constrained.addFeatures(sortedAddrsByDistance);
 
-		MASSGIS.renderAddressList();
-				$('#addr_list > div').scrollTo(0);
-	});
+			MASSGIS.renderAddressList();
+			$('#addr_list > div').scrollTo(0);
+		});
 
-	$('#search_query').on("click",function() {
-		$('#addr_list').css('display','none');
-		$('#addr_query').css('display','block');
-		$('#addr_query').height($('#addr_list').height());
-		$('#addr_query_res').height($('#addr_list').height() - $('#addr_query_inputs').height() - $('#addr_query header').height());
-		$('#select_all_addr').on("click",function() {
-				MASSGIS.showModalMessage('Working...',true);
-// Give the loading message a chance to fire.
-setTimeout(function() {
-			_.each(MASSGIS.addressQueryResults,function(f) {
-				var linkedAddr = MASSGIS.linkedAddressLayer.getFeatureByFid(f.fid);
-				if (!linkedAddr) {
-					var mafAddr = MASSGIS.lyr_maf.getFeatureByFid(f.fid);
-					mafAddr.selStatus = 'pre_selected';
-					MASSGIS.linkedAddressLayer.addFeatures([mafAddr]);
+		$('#search_query').on("click", function () {
+			$('#addr_list').css('display', 'none');
+			$('#addr_query').css('display', 'block');
+			$('#addr_query').height($('#addr_list').height());
+			$('#addr_query_res').height($('#addr_list').height() - $('#addr_query_inputs').height() - $('#addr_query header').height());
+			$('#select_all_addr').on("click", function () {
+				MASSGIS.showModalMessage('Working...', true);
+				// Give the loading message a chance to fire.
+				setTimeout(function () {
+					_.each(MASSGIS.addressQueryResults, function (f) {
+						var linkedAddr = MASSGIS.linkedAddressLayer.getFeatureByFid(f.fid);
+						if (!linkedAddr) {
+							var mafAddr = MASSGIS.lyr_maf.getFeatureByFid(f.fid);
+							mafAddr.selStatus = 'pre_selected';
+							MASSGIS.linkedAddressLayer.addFeatures([mafAddr]);
 
-					var addr_pt = MASSGIS.lyr_address_points.getFeaturesByAttribute("address_point_id",mafAddr.attributes.address_point_id);
-					$.each(addr_pt, function(idx, feature) {
-						MASSGIS.preSelectionLayer.addFeatures([feature.clone()]);
+							var addr_pt = MASSGIS.lyr_address_points.getFeaturesByAttribute("address_point_id", mafAddr.attributes.address_point_id);
+							$.each(addr_pt, function (idx, feature) {
+								MASSGIS.preSelectionLayer.addFeatures([feature.clone()]);
+							});
+						}
 					});
-				}
-			});
-			MASSGIS.renderLinkedAddresses();
-			MASSGIS.preSelectionLayer.redraw();
-			MASSGIS.hideModalMessage();
-},100);
-		});
-	});
-
-	$('#search_status').on("click",function() {
-		$('#addr_query').css('display','none');
-		$('#addr_list').css('display','block');
-		MASSGIS.addressListMode = 'status';
-		MASSGIS.renderAddressList();
-	});
-
-	$('#addr_query').on("change","input", function(evt) {
-		var aQueryTerms = [];
-		$.each($("#addr_query input"), function(idx, elt) {
-			jElt = $(elt);
-			if (jElt.val()) {
-				aQueryTerms.push({"attr": jElt.attr('id'), "val": jElt.val()});
-			}
-		});
-		if (aQueryTerms.length == 0) {
-			return;
-		}
-
-		MASSGIS.addressQueryResults = [];
-		$.each(MASSGIS.lyr_maf.features, function(idx, feature) {
-			var m = true;
-			$.each(aQueryTerms, function(idx, term) {
-				if (feature.attributes.address_status == 'DELETED') {
-					m = false;
-					return false;
-				}
-				if (
-					!feature.attributes[term.attr]
-					|| (term.attr == 'full_number_standardized' && feature.attributes[term.attr].toUpperCase() != term.val.toUpperCase())
-					|| feature.attributes[term.attr].toUpperCase().indexOf(term.val.toUpperCase()) == -1
-				) {
-					m = false;
-					return false;
-				}
-			});
-			m && MASSGIS.addressQueryResults.push(feature);
-		});
-
-		//console.log(MASSGIS.addressQueryResults.length + " features found");
-		if (MASSGIS.addressQueryResults.length == 0) {
-			html = "<li style='color: #903'>No Matching Addresses Found</li>";
-		} else {
-			var html = $('#addressListTmpl').render(MASSGIS.addressQueryResults);
-		}
-		$('#addr_query ul').html(html);
-		$('#addr_query ul').listview('refresh');
-	});
-
-	$('#settings_clear').on("click",function() {
-		$('#linked_addrs_buttons #clear_button').trigger('click');
-
-		MASSGIS.showModalMessage('Clearing Data from This Device',true);
-		MASSGIS.lyr_address_points.saveDeferred = $.Deferred();
-		MASSGIS.lyr_maf.saveDeferred = $.Deferred();
-
-		$.when(MASSGIS.lyr_maf.saveDeferred,
-			MASSGIS.lyr_address_points.saveDeferred).then(
-				function() {
-					MASSGIS.mafDrawOffset = 1;
-					MASSGIS.linkAddressSpatial
-					MASSGIS.renderAddressList();
-					$('#addr_list > div').scrollTo(0);
+					MASSGIS.renderLinkedAddresses();
+					MASSGIS.preSelectionLayer.redraw();
 					MASSGIS.hideModalMessage();
-					MASSGIS.init_data = false;
+				}, 100);
+			});
+		});
+
+		$('#search_status').on("click", function () {
+			$('#addr_query').css('display', 'none');
+			$('#addr_list').css('display', 'block');
+			MASSGIS.addressListMode = 'status';
+			MASSGIS.renderAddressList();
+		});
+
+		$('#addr_query').on("change", "input", function (evt) {
+			var aQueryTerms = [];
+			$.each($("#addr_query input"), function (idx, elt) {
+				jElt = $(elt);
+				if (jElt.val()) {
+					aQueryTerms.push({ "attr": jElt.attr('id'), "val": jElt.val() });
 				}
-		);
-
-		window.setTimeout( function() {
-		if (MASSGIS.lyr_maf && MASSGIS.lyr_maf.features.length > 0) {
-			$.each(MASSGIS.lyr_maf.features, function(idx, obj) {
-				obj.state = OpenLayers.State.DELETE;
 			});
-			$('#settings_maf').html('');
-			MASSGIS.lyr_maf.strategies[1].save();
-			MASSGIS.lyr_maf.removeAllFeatures();
-		} else {
-			MASSGIS.lyr_maf.saveDeferred.resolve();
-		}
+			if (aQueryTerms.length == 0) {
+				return;
+			}
 
-		if (MASSGIS.lyr_address_points && MASSGIS.lyr_address_points.features.length > 0) {
-			$.each(MASSGIS.lyr_address_points.features, function(idx, obj) {
-				obj.state = OpenLayers.State.DELETE;
+			MASSGIS.addressQueryResults = [];
+			$.each(MASSGIS.lyr_maf.features, function (idx, feature) {
+				var m = true;
+				$.each(aQueryTerms, function (idx, term) {
+					if (feature.attributes.address_status == 'DELETED') {
+						m = false;
+						return false;
+					}
+					if (
+						!feature.attributes[term.attr]
+						|| (term.attr == 'full_number_standardized' && feature.attributes[term.attr].toUpperCase() != term.val.toUpperCase())
+						|| feature.attributes[term.attr].toUpperCase().indexOf(term.val.toUpperCase()) == -1
+					) {
+						m = false;
+						return false;
+					}
+				});
+				m && MASSGIS.addressQueryResults.push(feature);
 			});
-			$('#settings_addrs').html('');
-			MASSGIS.lyr_address_points.strategies[1].save();
-			MASSGIS.lyr_address_points.removeAllFeatures();
-		} else {
-			MASSGIS.lyr_address_points.saveDeferred.resolve();
-		}
-		MASSGIS.settings_updateUI();
-		},200);
-	});
 
-	$('#msag_community').on("change",function() {
-		$('#settings_syncnow').attr('disabled',false).button('refresh');
-	});
+			//console.log(MASSGIS.addressQueryResults.length + " features found");
+			if (MASSGIS.addressQueryResults.length == 0) {
+				html = "<li style='color: #903'>No Matching Addresses Found</li>";
+			} else {
+				var html = $('#addressListTmpl').render(MASSGIS.addressQueryResults);
+			}
+			$('#addr_query ul').html(html);
+			$('#addr_query ul').listview('refresh');
+		});
 
-	$('#settings_syncnow').on("click",function() {
-		if (MASSGIS.lyr_address_points.features.length > 0 || MASSGIS.lyr_maf.features.length > 0) {
-			alert('Please clear records before downloading new records.');
-			return;
-		}
-		MASSGIS.showModalMessage('Syncing Address Data from Server',true);
-		window.setTimeout(function() {
-			var mafDef = MASSGIS.sync_maf();
-			var addrDef = MASSGIS.sync_address_points();
-			MASSGIS.dataSyncStatus = 'in_process';
-			$.when(mafDef, addrDef).done(
-					function() {
+		$('#settings_clear').on("click", function () {
+			$('#linked_addrs_buttons #clear_button').trigger('click');
+
+			MASSGIS.showModalMessage('Clearing Data from This Device', true);
+			MASSGIS.lyr_address_points.saveDeferred = $.Deferred();
+			MASSGIS.lyr_maf.saveDeferred = $.Deferred();
+
+			$.when(MASSGIS.lyr_maf.saveDeferred,
+				MASSGIS.lyr_address_points.saveDeferred).then(
+					function () {
+						MASSGIS.mafDrawOffset = 1;
+						MASSGIS.linkAddressSpatial
+						MASSGIS.renderAddressList();
+						$('#addr_list > div').scrollTo(0);
+						MASSGIS.hideModalMessage();
+						MASSGIS.init_data = false;
+					}
+				);
+
+			window.setTimeout(function () {
+				if (MASSGIS.lyr_maf && MASSGIS.lyr_maf.features.length > 0) {
+					$.each(MASSGIS.lyr_maf.features, function (idx, obj) {
+						obj.state = OpenLayers.State.DELETE;
+					});
+					$('#settings_maf').html('');
+					MASSGIS.lyr_maf.strategies[1].save();
+					MASSGIS.lyr_maf.removeAllFeatures();
+				} else {
+					MASSGIS.lyr_maf.saveDeferred.resolve();
+				}
+
+				if (MASSGIS.lyr_address_points && MASSGIS.lyr_address_points.features.length > 0) {
+					$.each(MASSGIS.lyr_address_points.features, function (idx, obj) {
+						obj.state = OpenLayers.State.DELETE;
+					});
+					$('#settings_addrs').html('');
+					MASSGIS.lyr_address_points.strategies[1].save();
+					MASSGIS.lyr_address_points.removeAllFeatures();
+				} else {
+					MASSGIS.lyr_address_points.saveDeferred.resolve();
+				}
+				MASSGIS.settings_updateUI();
+			}, 200);
+		});
+
+		$('#msag_community').on("change", function () {
+			$('#settings_syncnow').attr('disabled', false).button('refresh');
+		});
+
+		$('#settings_syncnow').on("click", function () {
+			if (MASSGIS.lyr_address_points.features.length > 0 || MASSGIS.lyr_maf.features.length > 0) {
+				alert('Please clear records before downloading new records.');
+				return;
+			}
+			MASSGIS.showModalMessage('Syncing Address Data from Server', true);
+			window.setTimeout(function () {
+				var mafDef = MASSGIS.sync_maf();
+				var addrDef = MASSGIS.sync_address_points();
+				MASSGIS.dataSyncStatus = 'in_process';
+				$.when(mafDef, addrDef).done(
+					function () {
 						MASSGIS.mafDrawOffset = 1;
 						MASSGIS.renderAddressList();
 						$('#addr_list > div').scrollTo(0);
@@ -465,7 +465,7 @@ setTimeout(function() {
 						MASSGIS.init_data = false;
 					}
 				).fail(
-					function() {
+					function () {
 						mafDef.abort();
 						mafDef.__ABORTED__ = true;
 						addrDef.abort();
@@ -474,861 +474,899 @@ setTimeout(function() {
 						MASSGIS.init_data = false;
 					}
 				);
-		},0);
-	});
-
-	$('#settings_sync_tiles').on("click",function() {
-		MASSGIS.fetchTilesIntoDb();
-	});
-
-	$('#settings_upload').on("click",function() {
-
-		var isDirty = false;
-		$.each(MASSGIS.lyr_maf.features, function(idx, feature) {
-			if (feature.attributes.__MODIFIED__) {
-				isDirty = true;
-				return false;
-			}
-		});
-		!isDirty && $.each(MASSGIS.lyr_address_points.features, function(idx, feature) {
-			if (feature.attributes.__MODIFIED__) {
-				isDirty = true;
-				return false;
-			}
+			}, 0);
 		});
 
-		if (!isDirty) {
-			alert("There are no changes to submit at this time");
-			return;
-		}
-
-		$('#linked_addrs_buttons #clear_button').trigger('click');
-		if (!MASSGIS.username) {
-			$('#save_email_form').on("submit", function() {
-				return false;
-			});
-			$('#login_popup a[data-icon="check"]').on("click",function(e) {
-				MASSGIS.username = $('#login_username').val();
-				MASSGIS.submit_address_points();
-				MASSGIS.submit_maf_records();
-			});
-			$("#login_popup").popup().popup("open");
-		}
-		else {
-			MASSGIS.submit_address_points();
-			MASSGIS.submit_maf_records();
-		}
-	});
-
-	$('#linked_addrs_buttons #clear_button').on("click",function() {
-		MASSGIS.preSelectionLayer.removeAllFeatures();
-		MASSGIS.selectionLayer.removeAllFeatures();
-		MASSGIS.linkedAddressLayer.removeAllFeatures();
-	});
-
-	$('#linked_addrs_buttons #undo_button').on("click",function() {
-		var nothing_to_undo = false;
-		MASSGIS.showModalMessage('Working...',true);
-// Give the loading message a chance to fire.
-setTimeout(function() {
-		if (MASSGIS.undoStack) {
-//console.dir(MASSGIS.undoStack);
-			if (MASSGIS.undoStack.action == 'click_to_delete') {
-				MASSGIS.undoStack.f.attributes.address_point_id = MASSGIS.undoStack.address_point_id;
-				MASSGIS.undoStack.f.attributes.edit_status = MASSGIS.undoStack.edit_status;
-				MASSGIS.undoStack.f.attributes.status_color = MASSGIS.undoStack.status_color;
-				MASSGIS.linkedAddressLayer.addFeatures([MASSGIS.undoStack.f]);
-
-				// There is no more FULL_ADDR, so this doesn't really do anything useful other than
-				// return the undo record.  Lucky for us, there is only one.
-				var mafFeature = MASSGIS.lyr_maf.getFeaturesByAttribute('master_address_id',MASSGIS.undoStack.f.attributes.master_address_id)[0];
-				mafFeature.attributes.edit_status = MASSGIS.undoStack.edit_status;
-				mafFeature.state = OpenLayers.State.UPDATE;
-				MASSGIS.lyr_maf.strategies[1].save();
-
-				MASSGIS.renderLinkedAddresses();
-				MASSGIS.renderAddressList();
-
-				if (MASSGIS.undoStack.address_point) {
-					var addrPt = MASSGIS.lyr_address_points.getFeaturesByAttribute("address_point_id",MASSGIS.undoStack.address_point_id)[0];
-					addrPt.attributes.address_status = MASSGIS.undoStack.address_point.address_status;
-					addrPt.attributes.status_color = MASSGIS.undoStack.address_point.status_color;
-					addrPt.state = OpenLayers.State.UPDATE;
-					MASSGIS.lyr_address_points.strategies[1].save();
-					MASSGIS.lyr_address_points.reindex();
-					MASSGIS.lyr_address_points.redraw();
-				}
-			}
-			else if (MASSGIS.undoStack.action == 'delete_address_point') {
-				for (var i = 0; i < MASSGIS.undoStack.f.length; i++) {
-					var layer = MASSGIS.undoStack.f[i].layer;
-					var f = layer.getFeatureByFid(MASSGIS.undoStack.f[i].fid);
-					if (f) {
-						f.state = OpenLayers.State.DELETE;
-					}
-					layer.addFeatures([MASSGIS.undoStack.f[i]]);
-					MASSGIS.undoStack.f[i].state = OpenLayers.INSERT;
-					layer.strategies && layer.strategies[1].save();
-					layer.spatialIndex && layer.reindex();
-					layer.redraw();
-				}
-			}
-			else if (MASSGIS.undoStack.action == 'ignore_address_point') {
-
-				// first, remove the split-off point (if it exists)
-				if (MASSGIS.undoStack.newPoint) {
-					MASSGIS.undoStack.newPoint.state = OpenLayers.State.DELETE;
-					MASSGIS.lyr_address_points.strategies[1].save();
-				}
-
-				// next, delete out all the points that were modified by this operation
-				// and re-add the undo-stack version of the point
-				for (var i = 0; i < MASSGIS.undoStack.f.length; i++) {
-					var layer = MASSGIS.undoStack.f[i].layer;
-					var f = layer.getFeatureByFid(MASSGIS.undoStack.f[i].fid);
-					if (f) {
-						f.state = OpenLayers.State.DELETE;
-					}
-					layer.addFeatures([MASSGIS.undoStack.f[i]]);
-					MASSGIS.undoStack.f[i].state = OpenLayers.State.INSERT;
-					layer.strategies && layer.strategies[1].save();
-					layer.spatialIndex && layer.reindex();
-					layer.redraw();
-				}
-
-				// finally, go through each address point id that was modified (nulled, probably)
-				// and re-set it back to it's original value
-				var addrPtId = MASSGIS.undoStack.f[0].attributes.address_point_id;
-				$.each(MASSGIS.undoStack.madRecIds, function(idx, madRec) {
-					madRec.attributes.address_point_id = addrPtId;
-				});
-			}
-			else if (MASSGIS.undoStack.action == 'link') {
-				// Restore orignal address_point_id's to MAF(s) as well as any hidden ones that were processed.
-				var modifiedFeatures = MASSGIS.undoStack.lyr_mafModified;
-				for (var i = 0; i < modifiedFeatures.length; i++) {
-					var f = MASSGIS.lyr_maf.getFeatureByFid(modifiedFeatures[i].fid);
-					$.each(["address_point_id","status_color","address_status","edit_status'"], function(idx, prop) {
-						f.attributes[prop] = modifiedFeatures[i].attributes[prop];
-					});
-					f.state = OpenLayers.State.UPDATE;
-				}
-				MASSGIS.lyr_maf.strategies[1].save();
-				MASSGIS.lyr_maf.reindex();
-				MASSGIS.renderAddressList();
-				console.log("original address_point_id's restored");
-
-				// Remove the entire MP(s) that may have been split to death.  Then put the original one(s) back in.
-				var fidsAdded = {}; // Make sure not to add any MP's more than once.
-				for (var i = 0; i < MASSGIS.undoStack.lyr_address_pointsModified.length; i++) {
-					var f = MASSGIS.lyr_address_points.getFeatureByFid(MASSGIS.undoStack.lyr_address_pointsModified[i].fid);
-					f.state = OpenLayers.State.DELETE;
-					MASSGIS.lyr_address_points.strategies[1].save();
-					//MASSGIS.lyr_address_points.removeFeatures([f]); // COMMENT
-					if (!fidsAdded[MASSGIS.undoStack.lyr_address_pointsModified[i].fid]) {
-						MASSGIS.lyr_address_points.addFeatures([MASSGIS.undoStack.lyr_address_pointsModified[i]]);
-						MASSGIS.undoStack.lyr_address_pointsModified[i].state = OpenLayers.State.UPDATE;
-						fidsAdded[MASSGIS.undoStack.lyr_address_pointsModified[i].fid] = true;
-					}
-				}
-				console.log("original MP's restored");
-
-				// Remove the new MP(s).
-				$.each(MASSGIS.undoStack.lyr_address_pointsAdded, function(idx, addedPoint) {
-					addedPoint.state = OpenLayers.State.DELETE;
-					//MASSGIS.lyr_address_points.removeFeatures(addedPoint); // COMMENT
-				});
-				console.log("new MP removed");
-				MASSGIS.lyr_address_points.strategies[1].save();
-				MASSGIS.lyr_address_points.reindex();
-				MASSGIS.lyr_address_points.redraw();
-
-				MASSGIS.selectionLayer.removeAllFeatures();
-				MASSGIS.selectionLayer.addFeatures(MASSGIS.undoStack.selectionLayer);
-				console.log("selectionLayer restored");
-				MASSGIS.selectionLayer.redraw();
-
-				MASSGIS.linkedAddressLayer.addFeatures(MASSGIS.undoStack.linkedAddressLayer);
-				console.log("linkedAddressLayer restored");
-				MASSGIS.renderLinkedAddresses();
-			}
-			else {
-				nothing_to_undo = true;
-			}
-		}
-		else {
-			nothing_to_undo = true;
-		}
-		MASSGIS.undoStack = {};
-			MASSGIS.hideModalMessage();
-			if (nothing_to_undo) {
-					alert('Nothing to undo!');
-			}
-		else {
-			MASSGIS.map.pan(1,1); // This nudge takes care of Canvas labeling artifacts.
-		}
-},100);
-	});
-
-	$('#linked_addrs_buttons #link_button').on("click",function() {
-
-		var allLinkedAddrsPreSelected = true;
-		$.each(MASSGIS.linkedAddressLayer.features, function(idx, feature) {
-			if (feature.selStatus == 'selected') {
-				allLinkedAddrsPreSelected = false;
-				return false;
-			}
+		$('#settings_sync_tiles').on("click", function () {
+			MASSGIS.fetchTilesIntoDb();
 		});
-		if (MASSGIS.preSelectionLayer.features.length == 1 && MASSGIS.selectionLayer.features.length < 1 && allLinkedAddrsPreSelected) {
-			// This is the 'orange link'.  If only 1 MP (or point) is preSelected (i.e. orange), and everything
-			// in the linked addr list is orange, then link that MP (or point) to everything in the linked addr list
-			$.each(MASSGIS.preSelectionLayer.features[0].geometry.components, function(idx, component) {
-				var f = MASSGIS.preSelectionLayer.features[0].clone();
-				f.geometry.components = [component];
-				MASSGIS.selectionLayer.addFeatures([f]);
-			});
-			MASSGIS.preSelectionLayer.removeAllFeatures();
-			$.each(MASSGIS.linkedAddressLayer.features,function(idx,feature){
-				feature.selStatus = 'selected';
-			});
-			MASSGIS.renderLinkedAddresses();
-		}
 
-		if (MASSGIS.selectionLayer.features.length < 1) {
-			alert('Please select at least one point to link.');
-			return;
-		}
+		$('#settings_upload').on("click", function () {
 
-		var c = 0;
-		$.each(MASSGIS.linkedAddressLayer.features,function(idx,linkedAddress) {
-			c += linkedAddress.selStatus == 'selected' ? 1 : 0;
-		});
-		if (c < 1 && $('#linked_addrs_buttons #link_button span span').text() != 'Mark Primary') {
-			alert('Please select at least one address to link.');
-			return;
-		}
-
-		MASSGIS.showModalMessage('Working...',true);
-// Give the loading message a chance to fire.
-setTimeout(function() {
-		MASSGIS.undoStack = {
-			 action							: 'link'
-			,lyr_address_pointsModified		: []
-			,lyr_address_pointsAdded		: []
-			,lyr_mafModified				: []
-			,selectionLayer					: []
-			,linkedAddressLayer				: []
-		};
-
-		var txId = MASSGIS.generateTXId();
-
-		// First check for special cases:
-		// 1.  Mark Primary Structure
-		// 2.  "Orange Link" MP to many addresses
-
-		// check for Marking Primary:
-		if ($('#linked_addrs_buttons #link_button span span').text() == 'Mark Primary') {
-			// Only one MP is preSelected and one of those points is selected.  Essentially perform an orange link
-			// w/ only the one point.  Then go back and mark the newly linked point as primary and the orphaned points
-			// as secondary as well as pointing the new orphans to the 'new' parent.
-			MASSGIS.undoStack.selectionLayer = MASSGIS.selectionLayer.features;
-			var origAddrPtId = MASSGIS.selectionLayer.features[0].attributes.address_point_id;
-			var origAddrPt = MASSGIS.lyr_address_points.getFeaturesByAttribute("address_point_id",origAddrPtId)[0];
-			if (origAddrPt.geometry.components.length == 1) {
-				alert("No need to mark this point as primary, since there's just one part");
-				return;
-			}
-
-			// first build the new "parent" point
-			var newFeature = new OpenLayers.Feature.Vector(MASSGIS.selectionLayer.features[0].geometry.clone());
-			$.each(origAddrPt.attributes, function(key, value) {
-				newFeature.attributes[key] = origAddrPt.attributes[key];
-			});
-			newFeature.attributes.status_color = "GREEN";
-			newFeature.attributes.geographic_edit_status = "MODIFIED";
-			newFeature.attributes.structure_type = "P";
-			newFeature.attributes.transaction_id = txId;
-			newFeature.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
-			newFeature.state = OpenLayers.State.INSERT;
-			newFeature.attributes.__MODIFIED__ = true;
-			MASSGIS.lyr_address_points.addFeatures([newFeature]);
-			MASSGIS.undoStack.lyr_address_pointsAdded.push(newFeature);
-
-			// now edit the "old" point
-			var pt = origAddrPt.clone();
-			pt.fid = origAddrPt.fid;
-			MASSGIS.undoStack.lyr_address_pointsModified.push(pt);
-			$.each(origAddrPt.geometry.components,function(idx,origComponent) {
-				if (newFeature.geometry.getBounds().equals(origComponent.getBounds())) {
-					origAddrPt.geometry.removePoint(origComponent);
+			var isDirty = false;
+			$.each(MASSGIS.lyr_maf.features, function (idx, feature) {
+				if (feature.attributes.__MODIFIED__) {
+					isDirty = true;
 					return false;
 				}
 			});
-			//origAddrPt.attributes.status_color = "???";
-			origAddrPt.attributes.address_status = "UNLINKED";
-			origAddrPt.attributes.geographic_edit_status = "SPLIT";
-			origAddrPt.attributes.structure_type = "S";
-			origAddrPt.attributes.parent_id = origAddrPtId;
-			origAddrPt.attributes.transaction_id = txId;
-			origAddrPt.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
-			origAddrPt.attributes.__MODIFIED__ = true;
-			var centroid = origAddrPt.geometry.getCentroid().clone();
-			centroid.transform("EPSG:900913","EPSG:26986");
-			origAddrPt.attributes.address_point_id = "M_" + Math.round(centroid.x) + "_" + Math.round(centroid.y);
-
-			origAddrPt.state = OpenLayers.State.UPDATE;
-
-			MASSGIS.lyr_address_points.strategies[1].save();
-			MASSGIS.lyr_address_points.reindex();
-			MASSGIS.lyr_address_points.redraw();
-			MASSGIS.hideModalMessage();
-
-			MASSGIS.selectionLayer.removeAllFeatures();
-			MASSGIS.selectionLayer.redraw();
-
-			MASSGIS.undoStack.linkedAddressLayer = MASSGIS.linkedAddressLayer.features;
-			MASSGIS.linkedAddressLayer.removeAllFeatures();
-			MASSGIS.renderLinkedAddresses();
-
-			return;
-
-		}
-
-		// Next let's figure out whether we're doing a split/merge, or just something simple.  Handle
-		// the simple case with simple logic.
-		var addrPointComponentCounts = {};
-		$.each(MASSGIS.selectionLayer.features,function(idx,selectionPoint) {
-			if (!addrPointComponentCounts[selectionPoint.attributes.address_point_id]) {
-				addrPointComponentCounts[selectionPoint.attributes.address_point_id] = 1;
-			} else {
-				addrPointComponentCounts[selectionPoint.attributes.address_point_id]++;
-			}
-		});
-		var uniqueAddrPtIds = $.map(addrPointComponentCounts,function(value, key) {return key;});
-		var isMerge = uniqueAddrPtIds.length > 1;
-
-		var isSplit = false;
-		$.each(uniqueAddrPtIds,function(idx,addrPtId) {
-			var origPoint = MASSGIS.lyr_address_points.getFeaturesByAttribute("address_point_id", addrPtId);
-			if (origPoint.length > 1) {
-				alert("Error:  Two Points in Address Point Database with address_point_id = " + addrPtId);
-				throw {"error": "true", "msg" : "why are there two points in the db with address_point_id = " + addrPtId};
-			}
-			origPoint = origPoint[0];
-			if (origPoint.geometry.components.length > addrPointComponentCounts[addrPtId]) {
-				isSplit = true;
-				return false;
-			}
-		});
-
-		if (!isSplit && !isMerge) {
-			//Ok, it's a "simple" linkage -- UC#11
-			var origAddressPoint = MASSGIS.lyr_address_points.getFeaturesByAttribute("address_point_id", uniqueAddrPtIds[0])[0];
-			var f = origAddressPoint.clone();
-			f.fid = origAddressPoint.fid;
-			MASSGIS.undoStack.lyr_address_pointsModified.push(f);
-			origAddressPoint.attributes.status_color = "GREEN";
-			origAddressPoint.attributes.address_status = "LINKED";
-			origAddressPoint.attributes.transaction_id = txId;
-			origAddressPoint.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
-			origAddressPoint.state = OpenLayers.State.UPDATE;
-			origAddressPoint.attributes.__MODIFIED__ = true;
-
-			// now go through the MAD records and null all records that have this addr point id
-			MASSGIS.lyr_maf.reindex();
-			var toBeRelabeled = [];
-			$.each(MASSGIS.lyr_maf.getFeaturesByAttribute("address_point_id",uniqueAddrPtIds[0]), function(idx, madRec) {
-				var f = madRec.clone();
-				f.fid = madRec.fid;
-				MASSGIS.undoStack.lyr_mafModified.push(f);
-				madRec.attributes.status_color = "RED";
-				toBeRelabeled.push(madRec.attributes.address_point_id);
-				madRec.attributes.address_point_id = '';
-				madRec.attributes.address_status = 'UNLINKED';
-				madRec.attributes.edit_status = 'MODIFIED';
-				madRec.attributes.transaction_id = txId;
-				madRec.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
-				madRec.attributes.__MODIFIED__ = true;
-				madRec.state = OpenLayers.State.UPDATE;
-			});
-			MASSGIS.lyr_maf.reindex();
-
-			$.each(MASSGIS.linkedAddressLayer.features, function(idx, linkedRec) {
-				if (linkedRec.selStatus != 'selected') {
-					return;
-				}
-				var madRec = MASSGIS.lyr_maf.getFeaturesByAttribute("master_address_id",linkedRec.attributes.master_address_id)[0];
-				madRec.attributes.address_point_id = origAddressPoint.attributes.address_point_id;
-				madRec.attributes.status_color = "GREEN";
-				madRec.attributes.address_status = 'LINKED';
-				madRec.attributes.edit_status = 'MODIFIED';
-				madRec.attributes.transaction_id = txId;
-				madRec.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
-				madRec.state = OpenLayers.State.UPDATE;
-				madRec.attributes.__MODIFIED__ = true;
-			});
-
-			MASSGIS.lyr_maf.strategies[1].save();
-			MASSGIS.lyr_maf.reindex();
-			MASSGIS.renderAddressList();
-
-			origAddressPoint.attributes.label_text = MASSGIS.lyr_address_points.draw_linked_st_num(origAddressPoint);
-			MASSGIS.lyr_address_points.strategies[1].save();
-			$.each(toBeRelabeled, function(idx, addrPtId) {
-				var fs = MASSGIS.lyr_address_points.getFeaturesByAttribute("address_point_id", addrPtId);
-				$.each(fs, function(idx, addrPt) {
-					addrPt.attributes.label_text = MASSGIS.lyr_address_points.draw_linked_st_num(addrPt);
-				});
-			});
-			MASSGIS.lyr_address_points.reindex();
-			MASSGIS.lyr_address_points.redraw();
-
-
-			var forRemovalLinkedAddresses = [];
-			$.each(MASSGIS.linkedAddressLayer.features,function(idx,linkedAddress) {
-				if (linkedAddress.selStatus == 'selected') {
-					forRemovalLinkedAddresses.push(linkedAddress);
-					MASSGIS.undoStack.linkedAddressLayer.push(linkedAddress);
+			!isDirty && $.each(MASSGIS.lyr_address_points.features, function (idx, feature) {
+				if (feature.attributes.__MODIFIED__) {
+					isDirty = true;
+					return false;
 				}
 			});
-			MASSGIS.linkedAddressLayer.removeFeatures(forRemovalLinkedAddresses);
-			MASSGIS.renderLinkedAddresses();
 
-			MASSGIS.undoStack.selectionLayer = MASSGIS.selectionLayer.features;
-			MASSGIS.selectionLayer.removeAllFeatures();
-			MASSGIS.selectionLayer.redraw();
-
-			MASSGIS.hideModalMessage();
-			return;
-		}
-
-
-		var points = [];
-		var addrpt_ids = [];
-		var deleted = [];
-		var toBeRelabeled = [];
-		var pointTypes = [];
-		// linking points procedure:
-		// 1.  Gather each of the single-part MASSGIS.selectionLayer.features points
-		//  1b.  As we're gathering them up, delete any identical MP parts from
-		//		- MASSGIS.preSelectionLayer.features
-		//		- MASSGIS.lyr_address_points.features
-		// 2.  Create a new MP feature made up of all the points gathered in 1.
-		// 3.  Assign that new MP feature a brand new address_point_id
-		// 4.  Copy that address_point_id to all "selected" lyr_maf records
-		$.each(MASSGIS.selectionLayer.features,function(idx,selectionPoint) {
-			points.push(selectionPoint.geometry.components[0].clone());
-			addrpt_ids.push(selectionPoint.attributes.address_point_id);
-			pointTypes.push(selectionPoint.attributes.point_type);
-
-			// Get address(es) whose address_point_id matches the selection point.
-			$.each(MASSGIS.lyr_address_points.getFeaturesByAttribute("address_point_id",selectionPoint.attributes.address_point_id),function(idx,addressMultiPoint) {
-				var addressMultiPointClone = addressMultiPoint.clone();
-				addressMultiPointClone.fid = addressMultiPoint.fid;
-				addressMultiPointClone.layer = addressMultiPoint.layer;
-
-				// Go through each component of the geom.
-				$.each(addressMultiPoint.geometry.components,function(idx,addressPoint) {
-
-					// Check for 'addressPoint' in case this point was already deleted from an earlier iteration.  E.g. 2 points from the same MP.
-					if (addressPoint && selectionPoint.geometry.getBounds().equals(addressPoint.getBounds())) {
-						if (addressMultiPoint.geometry.components.length == 1) {
-							// Nuke the whole thing if the addrMP only has 1 component.
-							addressMultiPoint.attributes.status_color = 'NONE';
-							addressMultiPoint.attributes.geographic_edit_status = 'DELETED';
-							addressMultiPoint.attributes.transaction_id = txId;
-							addressMultiPoint.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
-							addressMultiPoint.state = OpenLayers.State.UPDATE;
-							// Keep track of the deleted points, so we can fix them up later
-							deleted.push(addressMultiPoint);
-							addressMultiPoint.attributes.__MODIFIED__ = true;
-						} else {
-							// Nuke the selected point(s).
-							addressMultiPoint.geometry.removePoint(addressPoint);
-							// Next line is commented out so non-modified components won't have their icon changed.
-							toBeRelabeled.push(addressMultiPoint.attributes.address_point_id);
-							addressMultiPoint.attributes.geographic_edit_status = 'MODIFIED';
-							addressMultiPoint.attributes.address_status = 'SPLIT';
-							addressMultiPoint.attributes.transaction_id = txId;
-							addressMultiPoint.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
-							addressMultiPoint.state = OpenLayers.State.UPDATE;
-							addressMultiPoint.attributes.__MODIFIED__ = true;
-						}
-					}
-				});
-
-				if (addressMultiPoint.state == OpenLayers.State.UPDATE) {
-					MASSGIS.undoStack.lyr_address_pointsModified.push(addressMultiPointClone);
-				}
-
-			});
-
-		});
-		MASSGIS.lyr_address_points.strategies[1].save();
-		MASSGIS.lyr_address_points.reindex();
-
-		MASSGIS.undoStack.selectionLayer = MASSGIS.selectionLayer.features;
-		MASSGIS.selectionLayer.removeAllFeatures();
-		MASSGIS.selectionLayer.redraw();
-
-		var bounds = new OpenLayers.Bounds();
-		for (var i = 0; i < points.length; i++) {
-			bounds.extend(points[i]);
-		}
-		var centerLonLat = bounds.transform(
-			 MASSGIS.map.getProjectionObject()
-			,new OpenLayers.Projection('EPSG:26986')
-		).getCenterLonLat();
-		var address_point_id = 'M_' + Math.round(centerLonLat.lon) + '_' + Math.round(centerLonLat.lat);
-		var offset = 0;
-		while (addrpt_ids.indexOf(address_point_id) !== -1) {
-			offset++;
-			address_point_id = 'M_' + Math.round(centerLonLat.lon) + '_' + (Math.round(centerLonLat.lat) + offset);
-		}
-
-		pointTypes = $.unique(pointTypes);
-		var newPtType = false;
-		if (pointTypes.length == 1 && pointTypes[0] == 'ABC') {
-			newPtType = 'ABC';
-		}
-		var origAddressPoint = MASSGIS.lyr_address_points.getFeaturesByAttribute("address_point_id", uniqueAddrPtIds[0])[0];
-		var newFeature = new OpenLayers.Feature.Vector(new OpenLayers.Geometry.MultiPoint(points));
-		newFeature.attributes.address_point_id		= address_point_id;
-		newFeature.attributes.address_status		= 'LINKED';
-		newFeature.attributes.geographic_edit_status= 'ADDED';
-		newFeature.attributes.status_color			= 'GREEN';
-		newFeature.attributes.type_icon				= 'CIRCLE';
-		newFeature.attributes.site_id				= origAddressPoint.attributes.site_id;
-		newFeature.attributes.community_id			= origAddressPoint.attributes.community_id;
-		newFeature.attributes.loc_id				= origAddressPoint.attributes.loc_id;
-		newFeature.attributes.geographic_town_id	= origAddressPoint.attributes.geographic_town_id;
-		newFeature.attributes.transaction_id = txId;
-		newFeature.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
-		newPtType && (newFeature.attributes.point_type = newPtType);
-		newFeature.state = OpenLayers.State.INSERT;
-		newFeature.attributes.__MODIFIED__ = true;
-
-		// Null out the original address point id on any delete points address_point_id maf records
-		$.each(deleted, function(idx, deletedPoint) {
-			$.each(MASSGIS.lyr_maf.getFeaturesByAttribute("address_point_id",deletedPoint.attributes.address_point_id), function(idx, madRec) {
-				var f = madRec.clone();
-				f.fid = madRec.fid;
-				MASSGIS.undoStack.lyr_mafModified.push(f);
-				madRec.attributes.address_point_id = null;
-				madRec.attributes.status_color = "RED";
-				madRec.attributes.address_status = "UNLINKED";
-				madRec.attributes.transaction_id = txId;
-				madRec.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
-				madRec.state = OpenLayers.State.UPDATE;
-				madRec.attributes.__MODIFIED__ = true;
-			});
-		});
-
-		var forRemovalLinkedAddresses = [];
-		$.each(MASSGIS.linkedAddressLayer.features,function(idx,linkedAddress) {
-			if (linkedAddress.selStatus == 'selected') {
-				var f = MASSGIS.lyr_maf.getFeatureByFid(linkedAddress.fid);
-				var fClone = f.clone();
-				fClone.fid = f.fid;
-				MASSGIS.undoStack.lyr_mafModified.push(fClone);
-				f.attributes.address_point_id	= address_point_id;
-				f.attributes.address_status		= 'LINKED';
-				f.attributes.status_color		= 'GREEN';
-				f.attributes.transaction_id		= txId;
-				f.attributes.time_stamp			= new Date().toTimeString().split(" ")[0];
-				f.state							= OpenLayers.State.UPDATE;
-				f.attributes.__MODIFIED__		= true;
-				forRemovalLinkedAddresses.push(linkedAddress);
-				var f = linkedAddress.clone();
-				f.fid = linkedAddress.fid;
-				MASSGIS.undoStack.linkedAddressLayer.push(f);
-
-			}
-		});
-		MASSGIS.linkedAddressLayer.removeFeatures(forRemovalLinkedAddresses);
-		MASSGIS.renderLinkedAddresses();
-
-		// now that our maf points are linked, update the label_text accordingly
-		newFeature.attributes.label_text= MASSGIS.lyr_address_points.draw_linked_st_num(newFeature);
-		MASSGIS.lyr_address_points.addFeatures([newFeature]);
-		MASSGIS.undoStack.lyr_address_pointsAdded.push(newFeature);
-
-		$.each(toBeRelabeled, function(idx, addrPtId) {
-			var fs = MASSGIS.lyr_address_points.getFeaturesByAttribute("address_point_id", addrPtId);
-			$.each(fs, function(idx, addrPt) {
-				addrPt.attributes.label_text = MASSGIS.lyr_address_points.draw_linked_st_num(addrPt);
-			});
-		});
-		MASSGIS.lyr_address_points.strategies[1].save();
-		MASSGIS.lyr_address_points.reindex()
-		MASSGIS.lyr_maf.strategies[1].save();;
-		MASSGIS.lyr_maf.reindex();
-
-		MASSGIS.lyr_address_points.redraw();
-		MASSGIS.map.pan(1,1); // This nudge takes care of Canvas labeling artifacts.
-		MASSGIS.hideModalMessage();
-},100);
-	});
-
-	$('#addr_list > div').on('scroll', function() {
-		if ($(this).scrollTop() === 0) {
-			MASSGIS.mafDrawOffset = Math.max(1, MASSGIS.mafDrawOffset - 1);
-			MASSGIS.renderAddressList();
-			if (MASSGIS.mafDrawOffset === 1) {
-				$('#addr_list > div').scrollTo(0);
-			} else {
-				$('#addr_list > div').scrollTo('50%');
-			}
-		}
-		if ($(this).scrollTop() + $(this).innerHeight() >= $(this)[0].scrollHeight - 1) {
-			MASSGIS.mafDrawOffset = Math.min(MASSGIS.mafDrawOffset + 1, Math.ceil(MASSGIS.lyr_maf.features.length / MASSGIS.mafDrawMultiple));
-			MASSGIS.renderAddressList();
-			if (MASSGIS.mafDrawOffset === Math.ceil(MASSGIS.lyr_maf.features.length / MASSGIS.mafDrawMultiple)) {
-				$('#addr_list > div').scrollTo('100%');
-			} else {
-				$('#addr_list > div').scrollTo('50%');
-			}
-		}
-	});
-
-	$('#linked_addrs').on("click",".ui-btn-inner",function(e) {
-		// this is the "button text".  Why it doesn't trigger the actual button totally beats me.  Manually force it there.
-		$(this).parent().find('div[data-role="button"]').click();
-	});
-
-	$('#linked_addrs').on("click",'div[data-action="click_to_delete"]',function(e) {
-		e.stopPropagation();
-		var that = this;
-		$('#confirm_address_delete_popup').popup().popup("open");
-		$('#confirm_address_delete_popup a[data-icon=back]').on("click",function(e) {
-			e.stopPropagation();
-			$('#confirm_address_delete_popup a[data-icon=delete]').off("click");
-			$('#confirm_address_delete_popup a[data-icon=back]').off("click");
-
-			$('#confirm_address_delete_popup').popup().popup("close");
-		});
-
-		$('#confirm_address_delete_popup a[data-icon=delete]').on("click",function(e) {
-			e.stopPropagation();
-			$('#confirm_address_delete_popup a[data-icon=delete]').off("click");
-			$('#confirm_address_delete_popup a[data-icon=back]').off("click");
-
-			// remove from linked addrs
-			var f = MASSGIS.linkedAddressLayer.getFeatureByFid($(that).data('fid'));
-			MASSGIS.linkedAddressLayer.removeFeatures([f]);
-
-			// remove address_point_id reference from MAF
-			MASSGIS.undoStack = {
-				"action"			: 'click_to_delete',
-				"address_point_id"	: f.attributes.address_point_id,
-				"edit_status"		: f.attributes.edit_status,
-				"status_color"		: f.attributes.status_color
-			};
-
-
-			var txId = MASSGIS.generateTXId();
-
-			// get the lyr_maf version of this feature
-			if (f.attributes.master_address_id == 0) {
-				// this isn't a point that the server even knows about yet.  No need to retain it going forward
-				f = MASSGIS.lyr_maf.getFeatureByFid(f.fid);
-				f.state = OpenLayers.State.DELETE;
-				MASSGIS.undoStack.f = f;
-			} else {
-				f = MASSGIS.lyr_maf.getFeaturesByAttribute('master_address_id',f.attributes.master_address_id)[0];
-				MASSGIS.undoStack.f = f;
-				//edit_status changes
-				//f.attributes.edit_status = 'DELETED';
-				f.attributes.address_status = 'DELETED';
-				// leave a "null" address_point_id as null, but tack "_D" onto any legit addrptids
-				f.attributes.address_point_id = f.attributes.address_point_id ? f.attributes.address_point_id + "_D" : f.attributes.address_point_id;
-				f.attributes.status_color = 'NONE';
-				f.attributes.transaction_id = txId;
-				f.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
-				f.state = OpenLayers.State.UPDATE;
-				f.attributes.__MODIFIED__ = true;
-			}
-
-			MASSGIS.renderLinkedAddresses();
-			MASSGIS.renderAddressList();
-			MASSGIS.lyr_maf.strategies[1].save();
-			MASSGIS.lyr_maf.reindex();
-
-			if (!f.attributes.address_point_id) {
+			if (!isDirty) {
+				alert("There are no changes to submit at this time");
 				return;
 			}
 
-			// we also need to mark a potentially affected address point as red, if it were orphaned
-			addrPts = MASSGIS.lyr_address_points.getFeaturesByAttribute('address_point_id',MASSGIS.undoStack.address_point_id);
-			if (addrPts.length > 0) {
-				siblingMadRecs = MASSGIS.lyr_maf.getFeaturesByAttribute('address_point_id',MASSGIS.undoStack.address_point_id);
-				if (siblingMadRecs.length === 0) {
-					MASSGIS.undoStack.address_point = {
-						"status_color" :	addrPts[0].attributes.status_color,
-						"address_status" :	addrPts[0].attributes.address_status
-					};
-					addrPts[0].state = OpenLayers.State.UPDATE;
-					addrPts[0].attributes.__MODIFIED__ = true;
-					addrPts[0].attributes.status_color = "RED";
-					addrPts[0].attributes.address_status = "UNLINKED";
-					addrPts[0].attributes.label_text = MASSGIS.lyr_address_points.draw_linked_st_num(addrPts[0]);
-					addrPts[0].attributes.transaction_id = txId;
-					addrPts[0].attributes.time_stamp = new Date().toTimeString().split(" ")[0];
+			$('#linked_addrs_buttons #clear_button').trigger('click');
+			if (!MASSGIS.username) {
+				$('#save_email_form').on("submit", function () {
+					return false;
+				});
+				$('#login_popup a[data-icon="check"]').on("click", function (e) {
+					MASSGIS.username = $('#login_username').val();
+					MASSGIS.submit_address_points();
+					MASSGIS.submit_maf_records();
+				});
+				$("#login_popup").popup().popup("open");
+			}
+			else {
+				MASSGIS.submit_address_points();
+				MASSGIS.submit_maf_records();
+			}
+		});
+
+		$('#linked_addrs_buttons #clear_button').on("click", function () {
+			MASSGIS.preSelectionLayer.removeAllFeatures();
+			MASSGIS.selectionLayer.removeAllFeatures();
+			MASSGIS.linkedAddressLayer.removeAllFeatures();
+		});
+
+		$('#linked_addrs_buttons #undo_button').on("click", function () {
+			var nothing_to_undo = false;
+			MASSGIS.showModalMessage('Working...', true);
+			// Give the loading message a chance to fire.
+			setTimeout(function () {
+				if (MASSGIS.undoStack) {
+					//console.dir(MASSGIS.undoStack);
+					if (MASSGIS.undoStack.action == 'click_to_delete') {
+						MASSGIS.undoStack.f.attributes.address_point_id = MASSGIS.undoStack.address_point_id;
+						MASSGIS.undoStack.f.attributes.edit_status = MASSGIS.undoStack.edit_status;
+						MASSGIS.undoStack.f.attributes.status_color = MASSGIS.undoStack.status_color;
+						MASSGIS.linkedAddressLayer.addFeatures([MASSGIS.undoStack.f]);
+
+						// There is no more FULL_ADDR, so this doesn't really do anything useful other than
+						// return the undo record.  Lucky for us, there is only one.
+						var mafFeature = MASSGIS.lyr_maf.getFeaturesByAttribute('master_address_id', MASSGIS.undoStack.f.attributes.master_address_id)[0];
+						mafFeature.attributes.edit_status = MASSGIS.undoStack.edit_status;
+						mafFeature.state = OpenLayers.State.UPDATE;
+						MASSGIS.lyr_maf.strategies[1].save();
+
+						MASSGIS.renderLinkedAddresses();
+						MASSGIS.renderAddressList();
+
+						if (MASSGIS.undoStack.address_point) {
+							var addrPt = MASSGIS.lyr_address_points.getFeaturesByAttribute("address_point_id", MASSGIS.undoStack.address_point_id)[0];
+							addrPt.attributes.address_status = MASSGIS.undoStack.address_point.address_status;
+							addrPt.attributes.status_color = MASSGIS.undoStack.address_point.status_color;
+							addrPt.state = OpenLayers.State.UPDATE;
+							MASSGIS.lyr_address_points.strategies[1].save();
+							MASSGIS.lyr_address_points.reindex();
+							MASSGIS.lyr_address_points.redraw();
+						}
+					}
+					else if (MASSGIS.undoStack.action == 'delete_address_point') {
+						for (var i = 0; i < MASSGIS.undoStack.f.length; i++) {
+							var layer = MASSGIS.undoStack.f[i].layer;
+							var f = layer.getFeatureByFid(MASSGIS.undoStack.f[i].fid);
+							if (f) {
+								f.state = OpenLayers.State.DELETE;
+							}
+							layer.addFeatures([MASSGIS.undoStack.f[i]]);
+							MASSGIS.undoStack.f[i].state = OpenLayers.INSERT;
+							layer.strategies && layer.strategies[1].save();
+							layer.spatialIndex && layer.reindex();
+							layer.redraw();
+						}
+					}
+					else if (MASSGIS.undoStack.action == 'ignore_address_point') {
+
+						// first, remove the split-off point (if it exists)
+						if (MASSGIS.undoStack.newPoint) {
+							MASSGIS.undoStack.newPoint.state = OpenLayers.State.DELETE;
+							MASSGIS.lyr_address_points.strategies[1].save();
+						}
+
+						// next, delete out all the points that were modified by this operation
+						// and re-add the undo-stack version of the point
+						for (var i = 0; i < MASSGIS.undoStack.f.length; i++) {
+							var layer = MASSGIS.undoStack.f[i].layer;
+							var f = layer.getFeatureByFid(MASSGIS.undoStack.f[i].fid);
+							if (f) {
+								f.state = OpenLayers.State.DELETE;
+							}
+							layer.addFeatures([MASSGIS.undoStack.f[i]]);
+							MASSGIS.undoStack.f[i].state = OpenLayers.State.INSERT;
+							layer.strategies && layer.strategies[1].save();
+							layer.spatialIndex && layer.reindex();
+							layer.redraw();
+						}
+
+						// finally, go through each address point id that was modified (nulled, probably)
+						// and re-set it back to it's original value
+						var addrPtId = MASSGIS.undoStack.f[0].attributes.address_point_id;
+						$.each(MASSGIS.undoStack.madRecIds, function (idx, madRec) {
+							madRec.attributes.address_point_id = addrPtId;
+						});
+					}
+					else if (MASSGIS.undoStack.action == 'link') {
+						// Restore orignal address_point_id's to MAF(s) as well as any hidden ones that were processed.
+						var modifiedFeatures = MASSGIS.undoStack.lyr_mafModified;
+						for (var i = 0; i < modifiedFeatures.length; i++) {
+							var f = MASSGIS.lyr_maf.getFeatureByFid(modifiedFeatures[i].fid);
+							$.each(["address_point_id", "status_color", "address_status", "edit_status'"], function (idx, prop) {
+								f.attributes[prop] = modifiedFeatures[i].attributes[prop];
+							});
+							f.state = OpenLayers.State.UPDATE;
+						}
+						MASSGIS.lyr_maf.strategies[1].save();
+						MASSGIS.lyr_maf.reindex();
+						MASSGIS.renderAddressList();
+						console.log("original address_point_id's restored");
+
+						// Remove the entire MP(s) that may have been split to death.  Then put the original one(s) back in.
+						var fidsAdded = {}; // Make sure not to add any MP's more than once.
+						for (var i = 0; i < MASSGIS.undoStack.lyr_address_pointsModified.length; i++) {
+							var f = MASSGIS.lyr_address_points.getFeatureByFid(MASSGIS.undoStack.lyr_address_pointsModified[i].fid);
+							f.state = OpenLayers.State.DELETE;
+							MASSGIS.lyr_address_points.strategies[1].save();
+							//MASSGIS.lyr_address_points.removeFeatures([f]); // COMMENT
+							if (!fidsAdded[MASSGIS.undoStack.lyr_address_pointsModified[i].fid]) {
+								MASSGIS.lyr_address_points.addFeatures([MASSGIS.undoStack.lyr_address_pointsModified[i]]);
+								MASSGIS.undoStack.lyr_address_pointsModified[i].state = OpenLayers.State.UPDATE;
+								fidsAdded[MASSGIS.undoStack.lyr_address_pointsModified[i].fid] = true;
+							}
+						}
+						console.log("original MP's restored");
+
+						// Remove the new MP(s).
+						$.each(MASSGIS.undoStack.lyr_address_pointsAdded, function (idx, addedPoint) {
+							addedPoint.state = OpenLayers.State.DELETE;
+							//MASSGIS.lyr_address_points.removeFeatures(addedPoint); // COMMENT
+						});
+						console.log("new MP removed");
+						MASSGIS.lyr_address_points.strategies[1].save();
+						MASSGIS.lyr_address_points.reindex();
+						MASSGIS.lyr_address_points.redraw();
+
+						MASSGIS.selectionLayer.removeAllFeatures();
+						MASSGIS.selectionLayer.addFeatures(MASSGIS.undoStack.selectionLayer);
+						console.log("selectionLayer restored");
+						MASSGIS.selectionLayer.redraw();
+
+						MASSGIS.linkedAddressLayer.addFeatures(MASSGIS.undoStack.linkedAddressLayer);
+						console.log("linkedAddressLayer restored");
+						MASSGIS.renderLinkedAddresses();
+					}
+					else {
+						nothing_to_undo = true;
+					}
+				}
+				else {
+					nothing_to_undo = true;
+				}
+				MASSGIS.undoStack = {};
+				MASSGIS.hideModalMessage();
+				if (nothing_to_undo) {
+					alert('Nothing to undo!');
+				}
+				else {
+					MASSGIS.map.pan(1, 1); // This nudge takes care of Canvas labeling artifacts.
+				}
+			}, 100);
+		});
+
+		$('#linked_addrs_buttons #link_button').on("click", function () {
+
+			var allLinkedAddrsPreSelected = true;
+			$.each(MASSGIS.linkedAddressLayer.features, function (idx, feature) {
+				if (feature.selStatus == 'selected') {
+					allLinkedAddrsPreSelected = false;
+					return false;
+				}
+			});
+			if (MASSGIS.preSelectionLayer.features.length == 1 && MASSGIS.selectionLayer.features.length < 1 && allLinkedAddrsPreSelected) {
+				// This is the 'orange link'.  If only 1 MP (or point) is preSelected (i.e. orange), and everything
+				// in the linked addr list is orange, then link that MP (or point) to everything in the linked addr list
+				$.each(MASSGIS.preSelectionLayer.features[0].geometry.components, function (idx, component) {
+					var f = MASSGIS.preSelectionLayer.features[0].clone();
+					f.geometry.components = [component];
+					MASSGIS.selectionLayer.addFeatures([f]);
+				});
+				MASSGIS.preSelectionLayer.removeAllFeatures();
+				$.each(MASSGIS.linkedAddressLayer.features, function (idx, feature) {
+					feature.selStatus = 'selected';
+				});
+				MASSGIS.renderLinkedAddresses();
+			}
+
+			if (MASSGIS.selectionLayer.features.length < 1) {
+				alert('Please select at least one point to link.');
+				return;
+			}
+
+			var c = 0;
+			$.each(MASSGIS.linkedAddressLayer.features, function (idx, linkedAddress) {
+				c += linkedAddress.selStatus == 'selected' ? 1 : 0;
+			});
+			if (c < 1 && $('#linked_addrs_buttons #link_button span span').text() != 'Mark Primary') {
+				alert('Please select at least one address to link.');
+				return;
+			}
+
+			MASSGIS.showModalMessage('Working...', true);
+			// Give the loading message a chance to fire.
+			setTimeout(function () {
+				MASSGIS.undoStack = {
+					action: 'link'
+					, lyr_address_pointsModified: []
+					, lyr_address_pointsAdded: []
+					, lyr_mafModified: []
+					, selectionLayer: []
+					, linkedAddressLayer: []
+				};
+
+				var txId = MASSGIS.generateTXId();
+
+				// First check for special cases:
+				// 1.  Mark Primary Structure
+				// 2.  "Orange Link" MP to many addresses
+
+				// check for Marking Primary:
+				if ($('#linked_addrs_buttons #link_button span span').text() == 'Mark Primary') {
+					// Only one MP is preSelected and one of those points is selected.  Essentially perform an orange link
+					// w/ only the one point.  Then go back and mark the newly linked point as primary and the orphaned points
+					// as secondary as well as pointing the new orphans to the 'new' parent.
+					MASSGIS.undoStack.selectionLayer = MASSGIS.selectionLayer.features;
+					var origAddrPtId = MASSGIS.selectionLayer.features[0].attributes.address_point_id;
+					var origAddrPt = MASSGIS.lyr_address_points.getFeaturesByAttribute("address_point_id", origAddrPtId)[0];
+					if (origAddrPt.geometry.components.length == 1) {
+						alert("No need to mark this point as primary, since there's just one part");
+						return;
+					}
+
+					// first build the new "parent" point
+					var newFeature = new OpenLayers.Feature.Vector(MASSGIS.selectionLayer.features[0].geometry.clone());
+					$.each(origAddrPt.attributes, function (key, value) {
+						newFeature.attributes[key] = origAddrPt.attributes[key];
+					});
+					newFeature.attributes.status_color = "GREEN";
+					newFeature.attributes.geographic_edit_status = "MODIFIED";
+					newFeature.attributes.structure_type = "P";
+					newFeature.attributes.transaction_id = txId;
+					newFeature.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
+					newFeature.state = OpenLayers.State.INSERT;
+					newFeature.attributes.__MODIFIED__ = true;
+					MASSGIS.lyr_address_points.addFeatures([newFeature]);
+					MASSGIS.undoStack.lyr_address_pointsAdded.push(newFeature);
+
+					// now edit the "old" point
+					var pt = origAddrPt.clone();
+					pt.fid = origAddrPt.fid;
+					MASSGIS.undoStack.lyr_address_pointsModified.push(pt);
+					$.each(origAddrPt.geometry.components, function (idx, origComponent) {
+						if (newFeature.geometry.getBounds().equals(origComponent.getBounds())) {
+							origAddrPt.geometry.removePoint(origComponent);
+							return false;
+						}
+					});
+					//origAddrPt.attributes.status_color = "???";
+					origAddrPt.attributes.address_status = "UNLINKED";
+					origAddrPt.attributes.geographic_edit_status = "SPLIT";
+					origAddrPt.attributes.structure_type = "S";
+					origAddrPt.attributes.parent_id = origAddrPtId;
+					origAddrPt.attributes.transaction_id = txId;
+					origAddrPt.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
+					origAddrPt.attributes.__MODIFIED__ = true;
+					var centroid = origAddrPt.geometry.getCentroid().clone();
+					centroid.transform("EPSG:900913", "EPSG:26986");
+					origAddrPt.attributes.address_point_id = "M_" + Math.round(centroid.x) + "_" + Math.round(centroid.y);
+
+					origAddrPt.state = OpenLayers.State.UPDATE;
+
 					MASSGIS.lyr_address_points.strategies[1].save();
 					MASSGIS.lyr_address_points.reindex();
 					MASSGIS.lyr_address_points.redraw();
+					MASSGIS.hideModalMessage();
+
+					MASSGIS.selectionLayer.removeAllFeatures();
+					MASSGIS.selectionLayer.redraw();
+
+					MASSGIS.undoStack.linkedAddressLayer = MASSGIS.linkedAddressLayer.features;
+					MASSGIS.linkedAddressLayer.removeAllFeatures();
+					MASSGIS.renderLinkedAddresses();
+
+					return;
+
+				}
+
+				// Next let's figure out whether we're doing a split/merge, or just something simple.  Handle
+				// the simple case with simple logic.
+				var addrPointComponentCounts = {};
+				$.each(MASSGIS.selectionLayer.features, function (idx, selectionPoint) {
+					if (!addrPointComponentCounts[selectionPoint.attributes.address_point_id]) {
+						addrPointComponentCounts[selectionPoint.attributes.address_point_id] = 1;
+					} else {
+						addrPointComponentCounts[selectionPoint.attributes.address_point_id]++;
+					}
+				});
+				var uniqueAddrPtIds = $.map(addrPointComponentCounts, function (value, key) { return key; });
+				var isMerge = uniqueAddrPtIds.length > 1;
+
+				var isSplit = false;
+				$.each(uniqueAddrPtIds, function (idx, addrPtId) {
+					var origPoint = MASSGIS.lyr_address_points.getFeaturesByAttribute("address_point_id", addrPtId);
+					if (origPoint.length > 1) {
+						alert("Error:  Two Points in Address Point Database with address_point_id = " + addrPtId);
+						throw { "error": "true", "msg": "why are there two points in the db with address_point_id = " + addrPtId };
+					}
+					origPoint = origPoint[0];
+					if (origPoint.geometry.components.length > addrPointComponentCounts[addrPtId]) {
+						isSplit = true;
+						return false;
+					}
+				});
+
+				if (!isSplit && !isMerge) {
+					//Ok, it's a "simple" linkage -- UC#11
+					var origAddressPoint = MASSGIS.lyr_address_points.getFeaturesByAttribute("address_point_id", uniqueAddrPtIds[0])[0];
+					var f = origAddressPoint.clone();
+					f.fid = origAddressPoint.fid;
+					MASSGIS.undoStack.lyr_address_pointsModified.push(f);
+					origAddressPoint.attributes.status_color = "GREEN";
+					origAddressPoint.attributes.address_status = "LINKED";
+					origAddressPoint.attributes.transaction_id = txId;
+					origAddressPoint.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
+					origAddressPoint.state = OpenLayers.State.UPDATE;
+					origAddressPoint.attributes.__MODIFIED__ = true;
+
+					// now go through the MAD records and null all records that have this addr point id
+					MASSGIS.lyr_maf.reindex();
+					var toBeRelabeled = [];
+					$.each(MASSGIS.lyr_maf.getFeaturesByAttribute("address_point_id", uniqueAddrPtIds[0]), function (idx, madRec) {
+						var f = madRec.clone();
+						f.fid = madRec.fid;
+						MASSGIS.undoStack.lyr_mafModified.push(f);
+						madRec.attributes.status_color = "RED";
+						toBeRelabeled.push(madRec.attributes.address_point_id);
+						madRec.attributes.address_point_id = '';
+						madRec.attributes.address_status = 'UNLINKED';
+						madRec.attributes.edit_status = 'MODIFIED';
+						madRec.attributes.transaction_id = txId;
+						madRec.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
+						madRec.attributes.__MODIFIED__ = true;
+						madRec.state = OpenLayers.State.UPDATE;
+					});
+					MASSGIS.lyr_maf.reindex();
+
+					$.each(MASSGIS.linkedAddressLayer.features, function (idx, linkedRec) {
+						if (linkedRec.selStatus != 'selected') {
+							return;
+						}
+						var madRec = MASSGIS.lyr_maf.getFeaturesByAttribute("master_address_id", linkedRec.attributes.master_address_id)[0];
+						madRec.attributes.address_point_id = origAddressPoint.attributes.address_point_id;
+						madRec.attributes.status_color = "GREEN";
+						madRec.attributes.address_status = 'LINKED';
+						madRec.attributes.edit_status = 'MODIFIED';
+						madRec.attributes.transaction_id = txId;
+						madRec.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
+						madRec.state = OpenLayers.State.UPDATE;
+						madRec.attributes.__MODIFIED__ = true;
+					});
+
+					MASSGIS.lyr_maf.strategies[1].save();
+					MASSGIS.lyr_maf.reindex();
+					MASSGIS.renderAddressList();
+
+					origAddressPoint.attributes.label_text = MASSGIS.lyr_address_points.draw_linked_st_num(origAddressPoint);
+					MASSGIS.lyr_address_points.strategies[1].save();
+					$.each(toBeRelabeled, function (idx, addrPtId) {
+						var fs = MASSGIS.lyr_address_points.getFeaturesByAttribute("address_point_id", addrPtId);
+						$.each(fs, function (idx, addrPt) {
+							addrPt.attributes.label_text = MASSGIS.lyr_address_points.draw_linked_st_num(addrPt);
+						});
+					});
+					MASSGIS.lyr_address_points.reindex();
+					MASSGIS.lyr_address_points.redraw();
+
+
+					var forRemovalLinkedAddresses = [];
+					$.each(MASSGIS.linkedAddressLayer.features, function (idx, linkedAddress) {
+						if (linkedAddress.selStatus == 'selected') {
+							forRemovalLinkedAddresses.push(linkedAddress);
+							MASSGIS.undoStack.linkedAddressLayer.push(linkedAddress);
+						}
+					});
+					MASSGIS.linkedAddressLayer.removeFeatures(forRemovalLinkedAddresses);
+					MASSGIS.renderLinkedAddresses();
+
+					MASSGIS.undoStack.selectionLayer = MASSGIS.selectionLayer.features;
+					MASSGIS.selectionLayer.removeAllFeatures();
+					MASSGIS.selectionLayer.redraw();
+
+					MASSGIS.hideModalMessage();
+					return;
+				}
+
+
+				var points = [];
+				var addrpt_ids = [];
+				var deleted = [];
+				var toBeRelabeled = [];
+				var pointTypes = [];
+				// linking points procedure:
+				// 1.  Gather each of the single-part MASSGIS.selectionLayer.features points
+				//  1b.  As we're gathering them up, delete any identical MP parts from
+				//		- MASSGIS.preSelectionLayer.features
+				//		- MASSGIS.lyr_address_points.features
+				// 2.  Create a new MP feature made up of all the points gathered in 1.
+				// 3.  Assign that new MP feature a brand new address_point_id
+				// 4.  Copy that address_point_id to all "selected" lyr_maf records
+				$.each(MASSGIS.selectionLayer.features, function (idx, selectionPoint) {
+					points.push(selectionPoint.geometry.components[0].clone());
+					addrpt_ids.push(selectionPoint.attributes.address_point_id);
+					pointTypes.push(selectionPoint.attributes.point_type);
+
+					// Get address(es) whose address_point_id matches the selection point.
+					$.each(MASSGIS.lyr_address_points.getFeaturesByAttribute("address_point_id", selectionPoint.attributes.address_point_id), function (idx, addressMultiPoint) {
+						var addressMultiPointClone = addressMultiPoint.clone();
+						addressMultiPointClone.fid = addressMultiPoint.fid;
+						addressMultiPointClone.layer = addressMultiPoint.layer;
+
+						// Go through each component of the geom.
+						$.each(addressMultiPoint.geometry.components, function (idx, addressPoint) {
+
+							// Check for 'addressPoint' in case this point was already deleted from an earlier iteration.  E.g. 2 points from the same MP.
+							if (addressPoint && selectionPoint.geometry.getBounds().equals(addressPoint.getBounds())) {
+								if (addressMultiPoint.geometry.components.length == 1) {
+									// Nuke the whole thing if the addrMP only has 1 component.
+									addressMultiPoint.attributes.status_color = 'NONE';
+									addressMultiPoint.attributes.geographic_edit_status = 'DELETED';
+									addressMultiPoint.attributes.transaction_id = txId;
+									addressMultiPoint.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
+									addressMultiPoint.state = OpenLayers.State.UPDATE;
+									// Keep track of the deleted points, so we can fix them up later
+									deleted.push(addressMultiPoint);
+									addressMultiPoint.attributes.__MODIFIED__ = true;
+								} else {
+									// Nuke the selected point(s).
+									addressMultiPoint.geometry.removePoint(addressPoint);
+									// Next line is commented out so non-modified components won't have their icon changed.
+									toBeRelabeled.push(addressMultiPoint.attributes.address_point_id);
+									addressMultiPoint.attributes.geographic_edit_status = 'MODIFIED';
+									addressMultiPoint.attributes.address_status = 'SPLIT';
+									addressMultiPoint.attributes.transaction_id = txId;
+									addressMultiPoint.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
+									addressMultiPoint.state = OpenLayers.State.UPDATE;
+									addressMultiPoint.attributes.__MODIFIED__ = true;
+								}
+							}
+						});
+
+						if (addressMultiPoint.state == OpenLayers.State.UPDATE) {
+							MASSGIS.undoStack.lyr_address_pointsModified.push(addressMultiPointClone);
+						}
+
+					});
+
+				});
+				MASSGIS.lyr_address_points.strategies[1].save();
+				MASSGIS.lyr_address_points.reindex();
+
+				MASSGIS.undoStack.selectionLayer = MASSGIS.selectionLayer.features;
+				MASSGIS.selectionLayer.removeAllFeatures();
+				MASSGIS.selectionLayer.redraw();
+
+				var bounds = new OpenLayers.Bounds();
+				for (var i = 0; i < points.length; i++) {
+					bounds.extend(points[i]);
+				}
+				var centerLonLat = bounds.transform(
+					MASSGIS.map.getProjectionObject()
+					, new OpenLayers.Projection('EPSG:26986')
+				).getCenterLonLat();
+				var address_point_id = 'M_' + Math.round(centerLonLat.lon) + '_' + Math.round(centerLonLat.lat);
+				var offset = 0;
+				while (addrpt_ids.indexOf(address_point_id) !== -1) {
+					offset++;
+					address_point_id = 'M_' + Math.round(centerLonLat.lon) + '_' + (Math.round(centerLonLat.lat) + offset);
+				}
+
+				pointTypes = $.unique(pointTypes);
+				var newPtType = false;
+				if (pointTypes.length == 1 && pointTypes[0] == 'ABC') {
+					newPtType = 'ABC';
+				}
+				var origAddressPoint = MASSGIS.lyr_address_points.getFeaturesByAttribute("address_point_id", uniqueAddrPtIds[0])[0];
+				var newFeature = new OpenLayers.Feature.Vector(new OpenLayers.Geometry.MultiPoint(points));
+				newFeature.attributes.address_point_id = address_point_id;
+				newFeature.attributes.address_status = 'LINKED';
+				newFeature.attributes.geographic_edit_status = 'ADDED';
+				newFeature.attributes.status_color = 'GREEN';
+				newFeature.attributes.type_icon = 'CIRCLE';
+				newFeature.attributes.site_id = origAddressPoint.attributes.site_id;
+				newFeature.attributes.community_id = origAddressPoint.attributes.community_id;
+				newFeature.attributes.loc_id = origAddressPoint.attributes.loc_id;
+				newFeature.attributes.geographic_town_id = origAddressPoint.attributes.geographic_town_id;
+				newFeature.attributes.transaction_id = txId;
+				newFeature.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
+				newPtType && (newFeature.attributes.point_type = newPtType);
+				newFeature.state = OpenLayers.State.INSERT;
+				newFeature.attributes.__MODIFIED__ = true;
+
+				// Null out the original address point id on any delete points address_point_id maf records
+				$.each(deleted, function (idx, deletedPoint) {
+					$.each(MASSGIS.lyr_maf.getFeaturesByAttribute("address_point_id", deletedPoint.attributes.address_point_id), function (idx, madRec) {
+						var f = madRec.clone();
+						f.fid = madRec.fid;
+						MASSGIS.undoStack.lyr_mafModified.push(f);
+						madRec.attributes.address_point_id = null;
+						madRec.attributes.status_color = "RED";
+						madRec.attributes.address_status = "UNLINKED";
+						madRec.attributes.transaction_id = txId;
+						madRec.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
+						madRec.state = OpenLayers.State.UPDATE;
+						madRec.attributes.__MODIFIED__ = true;
+					});
+				});
+
+				var forRemovalLinkedAddresses = [];
+				$.each(MASSGIS.linkedAddressLayer.features, function (idx, linkedAddress) {
+					if (linkedAddress.selStatus == 'selected') {
+						var f = MASSGIS.lyr_maf.getFeatureByFid(linkedAddress.fid);
+						var fClone = f.clone();
+						fClone.fid = f.fid;
+						MASSGIS.undoStack.lyr_mafModified.push(fClone);
+						f.attributes.address_point_id = address_point_id;
+						f.attributes.address_status = 'LINKED';
+						f.attributes.status_color = 'GREEN';
+						f.attributes.transaction_id = txId;
+						f.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
+						f.state = OpenLayers.State.UPDATE;
+						f.attributes.__MODIFIED__ = true;
+						forRemovalLinkedAddresses.push(linkedAddress);
+						var f = linkedAddress.clone();
+						f.fid = linkedAddress.fid;
+						MASSGIS.undoStack.linkedAddressLayer.push(f);
+
+					}
+				});
+				MASSGIS.linkedAddressLayer.removeFeatures(forRemovalLinkedAddresses);
+				MASSGIS.renderLinkedAddresses();
+
+				// now that our maf points are linked, update the label_text accordingly
+				newFeature.attributes.label_text = MASSGIS.lyr_address_points.draw_linked_st_num(newFeature);
+				MASSGIS.lyr_address_points.addFeatures([newFeature]);
+				MASSGIS.undoStack.lyr_address_pointsAdded.push(newFeature);
+
+				$.each(toBeRelabeled, function (idx, addrPtId) {
+					var fs = MASSGIS.lyr_address_points.getFeaturesByAttribute("address_point_id", addrPtId);
+					$.each(fs, function (idx, addrPt) {
+						addrPt.attributes.label_text = MASSGIS.lyr_address_points.draw_linked_st_num(addrPt);
+					});
+				});
+				MASSGIS.lyr_address_points.strategies[1].save();
+				MASSGIS.lyr_address_points.reindex()
+				MASSGIS.lyr_maf.strategies[1].save();;
+				MASSGIS.lyr_maf.reindex();
+
+				MASSGIS.lyr_address_points.redraw();
+				MASSGIS.map.pan(1, 1); // This nudge takes care of Canvas labeling artifacts.
+				MASSGIS.hideModalMessage();
+			}, 100);
+		});
+
+		$('#addr_list > div').on('scroll', function () {
+			if ($(this).scrollTop() === 0) {
+				MASSGIS.mafDrawOffset = Math.max(1, MASSGIS.mafDrawOffset - 1);
+				MASSGIS.renderAddressList();
+				if (MASSGIS.mafDrawOffset === 1) {
+					$('#addr_list > div').scrollTo(0);
+				} else {
+					$('#addr_list > div').scrollTo('50%');
+				}
+			}
+			if ($(this).scrollTop() + $(this).innerHeight() >= $(this)[0].scrollHeight - 1) {
+				MASSGIS.mafDrawOffset = Math.min(MASSGIS.mafDrawOffset + 1, Math.ceil(MASSGIS.lyr_maf.features.length / MASSGIS.mafDrawMultiple));
+				MASSGIS.renderAddressList();
+				if (MASSGIS.mafDrawOffset === Math.ceil(MASSGIS.lyr_maf.features.length / MASSGIS.mafDrawMultiple)) {
+					$('#addr_list > div').scrollTo('100%');
+				} else {
+					$('#addr_list > div').scrollTo('50%');
 				}
 			}
 		});
-	});
 
-	$('#linked_addrs_buttons #add_addr_button').on("click", function() {
-		// add to MAF
-		if (MASSGIS.lyr_maf.features.length === 0) {
-			alert("please download data in your target community before adding an address");
-			return;
-		}
-		var f = MASSGIS.lyr_maf.getFeatureByFid(MASSGIS.lyr_maf.features[0].fid).clone();
-		f.state = OpenLayers.State.INSERT;
-		f.attributes.address_point_id = '';
-		f.attributes.address_status = 'ADDED';
-		f.attributes.building_name = null;
-		f.attributes.full_number_standardized = '';
-		f.attributes.last_edit_by = null;
-		f.attributes.last_edit_comments = null;
-		f.attributes.last_edit_date = null;
-		f.attributes.master_address_id = 'NEW-' + Math.random();
-		f.attributes.multt_id = null;
-		f.attributes.parent_address_id = null;
-		f.attributes.rel_loc = null;
-		f.attributes.site_id = null;
-		f.attributes.site_name = null;
-		f.attributes.status_color = 'RED';
-		f.attributes.street_name = '';
-		f.attributes.street_name_id = null;
-		f.attributes.subsite = null;
-		f.attributes.unit = null;
-		//edit_status changes
-		//f.attributes.address_status = 'UNASSIGNED';
-		//f.attributes.edit_status = 'ADDED';
-		f.attributes.transaction_id = MASSGIS.generateTXId();
-		f.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
-		f.attributes.__MODIFIED__ = true;
-		delete f.fid;
-		MASSGIS.lyr_maf.addFeatures([f]);
-		MASSGIS.lyr_maf.strategies[1].save();
+		$('#linked_addrs').on("click", ".ui-btn-inner", function (e) {
+			// this is the "button text".  Why it doesn't trigger the actual button totally beats me.  Manually force it there.
+			$(this).parent().find('div[data-role="button"]').click();
+		});
 
-		// add to linked addrs
-		MASSGIS.linkedAddressLayer.addFeatures([f]);
-		window.setTimeout(function() {
-			MASSGIS.renderLinkedAddresses();
-			MASSGIS.renderAddressList();
-			MASSGIS.new_address_fid = f.fid;
-			$('#linked_addrs div[data-action="click_to_edit"][data-fid=' + f.fid + ']').click();
-		}, 100);
+		$('#linked_addrs').on("click", 'div[data-action="click_to_delete"]', function (e) {
+			e.stopPropagation();
+			var that = this;
 
-		MASSGIS.undoStack = {};
-	});
-	$('#linked_addrs').on("click",'div[data-action="click_to_copy"]',function(e) {
-		e.stopPropagation();
-		// add to MAF
-		var f = MASSGIS.lyr_maf.getFeatureByFid($(this).data('fid')).clone();
-		f.state = OpenLayers.State.INSERT;
-		f.attributes.address_point_id = '';
-		//f.attributes.master_address_id = 0;
-		f.attributes.master_address_id = 'NEW-' + Math.random();
-		f.attributes.status_color = 'RED';
-		//edit_status changes
-		//f.attributes.address_status = 'UNASSIGNED';
-		//f.attributes.edit_status = 'ADDED';
-		f.attributes.address_status = 'ADDED';
-		f.attributes.transaction_id = MASSGIS.generateTXId();
-		f.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
-		f.attributes.__MODIFIED__ = true;
-		delete f.fid;
-		MASSGIS.lyr_maf.addFeatures([f]);
-		MASSGIS.lyr_maf.strategies[1].save();
-
-		// add to linked addrs
-		MASSGIS.linkedAddressLayer.addFeatures([f]);
-		window.setTimeout(function() {
-			MASSGIS.renderLinkedAddresses();
-			MASSGIS.renderAddressList();
-		}, 100);
-
-		MASSGIS.undoStack = {};
-	});
-
-	$('#edit_popup a[data-icon="delete"]').on("click",function(e) {
-		if (MASSGIS.new_address_fid) {
-			var f = MASSGIS.linkedAddressLayer.getFeatureByFid(MASSGIS.new_address_fid);
-			MASSGIS.linkedAddressLayer.removeFeatures([f]);
-
-			var f = MASSGIS.lyr_maf.getFeatureByFid(MASSGIS.new_address_fid);
-			if (f) {
-				f.state = OpenLayers.State.DELETE;
-				MASSGIS.lyr_maf.strategies[1].save();
+			var f = MASSGIS.linkedAddressLayer.getFeatureByFid($(that).data('fid'));
+			var toDelete = [];
+			if (f.selStatus == 'selected') {
+				// delete this f, and any other selected features
+				$.each(MASSGIS.linkedAddressLayer.features, function (idx, feature) {
+					if (feature.selStatus == 'selected') {
+						toDelete.push(feature);
+					}
+				});
+			} else {
+				// delete only this f
+				toDelete.push(f);
 			}
-		}
-	});
 
-	$('#edit_popup a[data-icon="check"]').on("click",function(e) {
-		// validation, need to enter a street name and number
-		if ($('#edit_street_name').val() == '') {
-			alert('please enter a street name');
-			return false;
-		}
-		if ($('#edit_full_number_standardized').val() == '') {
-			alert('please enter an address number');
-			return false;
-		}
+			if (toDelete.length > 1) {
+				$('#confirm_address_delete_popup a[data-icon="delete"] .ui-btn-text').html("Delete These " + toDelete.length + " Addresses?");
+			} else {
+				$('#confirm_address_delete_popup a[data-icon="delete"] .ui-btn-text').html("Delete This Address?");
+			}
+			$('#confirm_address_delete_popup').popup().popup("open");
+			$('#confirm_address_delete_popup a[data-icon=back]').on("click", function (e) {
+				e.stopPropagation();
+				$('#confirm_address_delete_popup a[data-icon=delete]').off("click");
+				$('#confirm_address_delete_popup a[data-icon=back]').off("click");
 
-		if (MASSGIS.new_address_fid) {
-			MASSGIS.new_address_fid = null;
-		}
-		var f = MASSGIS.linkedAddressLayer.getFeatureByFid($('#edit_popup').data('fid'));
-		var origSiteName = f.attributes.site_name;
-		var newSiteName = $('#edit_site_name').val();
-		if (origSiteName && origSiteName != newSiteName) {
-			var changeOthers = confirm("You have updated the site name of this address.  By changing this site name, you will update this site name for EVERY ADDRESS with this site name.  Are you sure you wish to continue?  Click 'ok' to make this change for ALL ADDRESSES with this site name, or 'cancel' to cancel this change.");
-			if (!changeOthers) {
+				$('#confirm_address_delete_popup').popup().popup("close");
+			});
+
+			$('#confirm_address_delete_popup a[data-icon=delete]').on("click", function (e) {
+				e.stopPropagation();
+				$('#confirm_address_delete_popup a[data-icon=delete]').off("click");
+				$('#confirm_address_delete_popup a[data-icon=back]').off("click");
+
+				$.each(toDelete, function (idx, f) {
+
+					// remove from linked addrs
+					MASSGIS.linkedAddressLayer.removeFeatures([f]);
+
+					// remove address_point_id reference from MAF
+					MASSGIS.undoStack = {
+						"action": 'click_to_delete',
+						"address_point_id": f.attributes.address_point_id,
+						"edit_status": f.attributes.edit_status,
+						"status_color": f.attributes.status_color
+					};
+
+
+					var txId = MASSGIS.generateTXId();
+
+					// get the lyr_maf version of this feature
+					if (f.attributes.master_address_id == 0) {
+						// this isn't a point that the server even knows about yet.  No need to retain it going forward
+						f = MASSGIS.lyr_maf.getFeatureByFid(f.fid);
+						f.state = OpenLayers.State.DELETE;
+						MASSGIS.undoStack.f = f;
+					} else {
+						f = MASSGIS.lyr_maf.getFeaturesByAttribute('master_address_id', f.attributes.master_address_id)[0];
+						MASSGIS.undoStack.f = f;
+						//edit_status changes
+						//f.attributes.edit_status = 'DELETED';
+						f.attributes.address_status = 'DELETED';
+						// leave a "null" address_point_id as null, but tack "_D" onto any legit addrptids
+						f.attributes.address_point_id = f.attributes.address_point_id ? f.attributes.address_point_id + "_D" : f.attributes.address_point_id;
+						f.attributes.status_color = 'NONE';
+						f.attributes.transaction_id = txId;
+						f.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
+						f.state = OpenLayers.State.UPDATE;
+						f.attributes.__MODIFIED__ = true;
+					}
+
+					MASSGIS.renderLinkedAddresses();
+					MASSGIS.renderAddressList();
+					MASSGIS.lyr_maf.strategies[1].save();
+					MASSGIS.lyr_maf.reindex();
+
+					if (!f.attributes.address_point_id) {
+						return;
+					}
+
+					// we also need to mark a potentially affected address point as red, if it were orphaned
+					addrPts = MASSGIS.lyr_address_points.getFeaturesByAttribute('address_point_id', MASSGIS.undoStack.address_point_id);
+					if (addrPts.length > 0) {
+						siblingMadRecs = MASSGIS.lyr_maf.getFeaturesByAttribute('address_point_id', MASSGIS.undoStack.address_point_id);
+						if (siblingMadRecs.length === 0) {
+							MASSGIS.undoStack.address_point = {
+								"status_color": addrPts[0].attributes.status_color,
+								"address_status": addrPts[0].attributes.address_status
+							};
+							addrPts[0].state = OpenLayers.State.UPDATE;
+							addrPts[0].attributes.__MODIFIED__ = true;
+							addrPts[0].attributes.status_color = "RED";
+							addrPts[0].attributes.address_status = "UNLINKED";
+							addrPts[0].attributes.label_text = MASSGIS.lyr_address_points.draw_linked_st_num(addrPts[0]);
+							addrPts[0].attributes.transaction_id = txId;
+							addrPts[0].attributes.time_stamp = new Date().toTimeString().split(" ")[0];
+							MASSGIS.lyr_address_points.strategies[1].save();
+							MASSGIS.lyr_address_points.reindex();
+							MASSGIS.lyr_address_points.redraw();
+						}
+					}
+				});
+			});
+		});
+
+		$('#linked_addrs_buttons #add_addr_button').on("click", function () {
+			// add to MAF
+			if (MASSGIS.lyr_maf.features.length === 0) {
+				alert("please download data in your target community before adding an address");
 				return;
 			}
-		}
-		$.each(f.attributes, function(attr, value) {
-			$('#edit_' + attr).length > 0 && (f.attributes[attr] = $('#edit_' + attr).val());
+			var f = MASSGIS.lyr_maf.getFeatureByFid(MASSGIS.lyr_maf.features[0].fid).clone();
+			f.state = OpenLayers.State.INSERT;
+			f.attributes.address_point_id = '';
+			f.attributes.address_status = 'ADDED';
+			f.attributes.building_name = null;
+			f.attributes.full_number_standardized = '';
+			f.attributes.last_edit_by = null;
+			f.attributes.last_edit_comments = null;
+			f.attributes.last_edit_date = null;
+			f.attributes.master_address_id = 'NEW-' + Math.random();
+			f.attributes.multt_id = null;
+			f.attributes.parent_address_id = null;
+			f.attributes.rel_loc = null;
+			f.attributes.site_id = null;
+			f.attributes.site_name = null;
+			f.attributes.status_color = 'RED';
+			f.attributes.street_name = '';
+			f.attributes.street_name_id = null;
+			f.attributes.subsite = null;
+			f.attributes.unit = null;
+			//edit_status changes
+			//f.attributes.address_status = 'UNASSIGNED';
+			//f.attributes.edit_status = 'ADDED';
+			f.attributes.transaction_id = MASSGIS.generateTXId();
+			f.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
+			f.attributes.__MODIFIED__ = true;
+			delete f.fid;
+			MASSGIS.lyr_maf.addFeatures([f]);
+			MASSGIS.lyr_maf.strategies[1].save();
+
+			// add to linked addrs
+			MASSGIS.linkedAddressLayer.addFeatures([f]);
+			window.setTimeout(function () {
+				MASSGIS.renderLinkedAddresses();
+				MASSGIS.renderAddressList();
+				MASSGIS.new_address_fid = f.fid;
+				$('#linked_addrs div[data-action="click_to_edit"][data-fid=' + f.fid + ']').click();
+			}, 100);
+
+			MASSGIS.undoStack = {};
 		});
-//		edit_status changes
-//		if (!f.attributes.edit_status || f.attributes.edit_status != "ADDED") {
-//			f.attributes.edit_status = 'MODIFIED';
-//		}
-		if (!f.attributes.address_status || f.attributes.address_status != "ADDED") {
-			f.attributes.address_status = 'MODIFIED';
-		}
-//		if (f.attributes.address_point_id) {
-//			f.attributes.status_color = 'GREEN';
-//		}
-		if (!MASSGIS.streets_to_street_id_hash[f.attributes.street_name]) {
-			//brand new street.  Give it a street_name_id of zero
-			f.attributes.street_name_id = 0;
-		} else if (f.attributes.street_name_id != MASSGIS.streets_to_street_id_hash[f.attributes.street_name]) {
-			f.attributes.street_name_id = MASSGIS.streets_to_street_id_hash[f.attributes.street_name];
-		}
+		$('#linked_addrs').on("click", 'div[data-action="click_to_copy"]', function (e) {
+			e.stopPropagation();
+			// add to MAF
+			var f = MASSGIS.lyr_maf.getFeatureByFid($(this).data('fid')).clone();
+			f.state = OpenLayers.State.INSERT;
+			f.attributes.address_point_id = '';
+			//f.attributes.master_address_id = 0;
+			f.attributes.master_address_id = 'NEW-' + Math.random();
+			f.attributes.status_color = 'RED';
+			//edit_status changes
+			//f.attributes.address_status = 'UNASSIGNED';
+			//f.attributes.edit_status = 'ADDED';
+			f.attributes.address_status = 'ADDED';
+			f.attributes.transaction_id = MASSGIS.generateTXId();
+			f.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
+			f.attributes.__MODIFIED__ = true;
+			delete f.fid;
+			MASSGIS.lyr_maf.addFeatures([f]);
+			MASSGIS.lyr_maf.strategies[1].save();
 
-		var txId = MASSGIS.generateTXId();
-		var timestamp = new Date().toTimeString().split(" ")[0];
+			// add to linked addrs
+			MASSGIS.linkedAddressLayer.addFeatures([f]);
+			window.setTimeout(function () {
+				MASSGIS.renderLinkedAddresses();
+				MASSGIS.renderAddressList();
+			}, 100);
 
-		// per dan's/mike's email on 9/25
-		if (!origSiteName && !newSiteName) {
-			// no changes to site_name_id, site_id or site_name
-		} else if (origSiteName && !newSiteName) {
-			// they blanked out the site name, so we'll do case C.
-			f.attributes.site_name = '';
+			MASSGIS.undoStack = {};
+		});
 
-			if (f.attributes.site_id) {
-				var others = MASSGIS.lyr_maf.getFeaturesByAttribute("site_id", f.attributes.site_id);
+		$('#edit_popup a[data-icon="delete"]').on("click", function (e) {
+			if (MASSGIS.new_address_fid) {
+				var f = MASSGIS.linkedAddressLayer.getFeatureByFid(MASSGIS.new_address_fid);
+				MASSGIS.linkedAddressLayer.removeFeatures([f]);
+
+				var f = MASSGIS.lyr_maf.getFeatureByFid(MASSGIS.new_address_fid);
+				if (f) {
+					f.state = OpenLayers.State.DELETE;
+					MASSGIS.lyr_maf.strategies[1].save();
+				}
+			}
+		});
+
+		$('#edit_popup a[data-icon="check"]').on("click", function (e) {
+			// validation, need to enter a street name and number
+			if ($('#edit_street_name').val() == '') {
+				alert('please enter a street name');
+				return false;
+			}
+			if ($('#edit_full_number_standardized').val() == '') {
+				alert('please enter an address number');
+				return false;
+			}
+
+			if (MASSGIS.new_address_fid) {
+				MASSGIS.new_address_fid = null;
+			}
+			var f = MASSGIS.linkedAddressLayer.getFeatureByFid($('#edit_popup').data('fid'));
+			var origSiteName = f.attributes.site_name;
+			var newSiteName = $('#edit_site_name').val();
+			if (origSiteName && origSiteName != newSiteName) {
+				var changeOthers = confirm("You have updated the site name of this address.  By changing this site name, you will update this site name for EVERY ADDRESS with this site name.  Are you sure you wish to continue?  Click 'ok' to make this change for ALL ADDRESSES with this site name, or 'cancel' to cancel this change.");
+				if (!changeOthers) {
+					return;
+				}
+			}
+			$.each(f.attributes, function (attr, value) {
+				$('#edit_' + attr).length > 0 && (f.attributes[attr] = $('#edit_' + attr).val());
+			});
+			//		edit_status changes
+			//		if (!f.attributes.edit_status || f.attributes.edit_status != "ADDED") {
+			//			f.attributes.edit_status = 'MODIFIED';
+			//		}
+			if (!f.attributes.address_status || f.attributes.address_status != "ADDED") {
+				f.attributes.address_status = 'MODIFIED';
+			}
+			//		if (f.attributes.address_point_id) {
+			//			f.attributes.status_color = 'GREEN';
+			//		}
+			if (!MASSGIS.streets_to_street_id_hash[f.attributes.street_name]) {
+				//brand new street.  Give it a street_name_id of zero
+				f.attributes.street_name_id = 0;
+			} else if (f.attributes.street_name_id != MASSGIS.streets_to_street_id_hash[f.attributes.street_name]) {
+				f.attributes.street_name_id = MASSGIS.streets_to_street_id_hash[f.attributes.street_name];
+			}
+
+			var txId = MASSGIS.generateTXId();
+			var timestamp = new Date().toTimeString().split(" ")[0];
+
+			// per dan's/mike's email on 9/25
+			if (!origSiteName && !newSiteName) {
+				// no changes to site_name_id, site_id or site_name
+			} else if (origSiteName && !newSiteName) {
+				// they blanked out the site name, so we'll do case C.
+				f.attributes.site_name = '';
+
+				if (f.attributes.site_id) {
+					var others = MASSGIS.lyr_maf.getFeaturesByAttribute("site_id", f.attributes.site_id);
+					if (others.length !== 0) {
+						$.each(others, function (idx, feature) {
+							feature.attributes.site_name = f.attributes.site_name;
+							feature.attributes.site_name_id = newSiteNameId;
+							if (feature.attributes.address_status != 'DELETED') {
+								feature.attributes.address_status = 'MODIFIED';
+							}
+							feature.attributes.transaction_id = txId;
+							feature.attributes.time_stamp = timestamp;
+							feature.state = OpenLayers.State.UPDATE;
+							feature.attributes.__MODIFIED__ = true;
+						});
+					}
+				}
+
+				var others = MASSGIS.lyr_maf.getFeaturesByAttribute("site_name", origSiteName);
 				if (others.length !== 0) {
-					$.each(others, function(idx, feature) {
+					$.each(others, function (idx, feature) {
 						feature.attributes.site_name = f.attributes.site_name;
 						feature.attributes.site_name_id = newSiteNameId;
 						if (feature.attributes.address_status != 'DELETED') {
@@ -1340,1837 +1378,1820 @@ setTimeout(function() {
 						feature.attributes.__MODIFIED__ = true;
 					});
 				}
-			}
 
-			var others = MASSGIS.lyr_maf.getFeaturesByAttribute("site_name", origSiteName);
-			if (others.length !== 0) {
-				$.each(others, function(idx, feature) {
-					feature.attributes.site_name = f.attributes.site_name;
-					feature.attributes.site_name_id = newSiteNameId;
-					if (feature.attributes.address_status != 'DELETED') {
-						feature.attributes.address_status = 'MODIFIED';
+			} else if (origSiteName != f.attributes.site_name && newSiteName) {
+				// This is both cases B and D
+				// 1. - site_name_id is set to the existing site_name_id for the newSiteName, or else zero
+				var newSiteNameId;
+				if (origSiteName) {
+					newSiteNameId = MASSGIS.sites_to_site_name_id_hash[newSiteName] || false;
+				} else {
+					newSiteNameId = MASSGIS.sites_to_site_name_id_hash[newSiteName] || 0;
+				}
+				newSiteNameId !== false && (f.attributes.site_name_id = newSiteNameId);
+
+				// this is a legit site, so go and find all the matching site_ids in the maf table and update them
+				if (f.attributes.site_id) {
+					var others = MASSGIS.lyr_maf.getFeaturesByAttribute("site_id", f.attributes.site_id);
+					if (others.length !== 0) {
+						$.each(others, function (idx, feature) {
+							feature.attributes.site_name = f.attributes.site_name;
+							newSiteNameId !== false && (feature.attributes.site_name_id = newSiteNameId);
+							if (feature.attributes.address_status != 'DELETED') {
+								feature.attributes.address_status = 'MODIFIED';
+							}
+							feature.attributes.transaction_id = txId;
+							feature.attributes.time_stamp = timestamp;
+							feature.state = OpenLayers.State.UPDATE;
+							feature.attributes.__MODIFIED__ = true;
+						});
 					}
-					feature.attributes.transaction_id = txId;
-					feature.attributes.time_stamp = timestamp;
-					feature.state = OpenLayers.State.UPDATE;
-					feature.attributes.__MODIFIED__ = true;
-				});
+				}
+
+				if (origSiteName) {
+					var others = MASSGIS.lyr_maf.getFeaturesByAttribute("site_name", origSiteName);
+					if (others.length !== 0) {
+						$.each(others, function (idx, feature) {
+							feature.attributes.site_name = f.attributes.site_name;
+							newSiteNameId !== false && (feature.attributes.site_name_id = newSiteNameId);
+							if (feature.attributes.address_status != 'DELETED') {
+								feature.attributes.address_status = 'MODIFIED';
+							}
+							feature.attributes.transaction_id = txId;
+							feature.attributes.time_stamp = timestamp;
+							feature.state = OpenLayers.State.UPDATE;
+							feature.attributes.__MODIFIED__ = true;
+						});
+					}
+				}
+
+				if (f.attributes.site_id === null) {
+					// If the user edits site_name for an address record where site_id is null, populate that site_name to all records with the same address_point_id.
+					var others = MASSGIS.lyr_maf.getFeaturesByAttribute("address_point_id", f.attributes.address_point_id);
+					$.each(others, function (idx, feature) {
+						feature.attributes.site_name = f.attributes.site_name;
+						newSiteNameId !== false && (feature.attributes.site_name_id = newSiteNameId);
+						if (feature.attributes.address_status != 'DELETED') {
+							feature.attributes.address_status = 'MODIFIED';
+						}
+						feature.attributes.transaction_id = txId;
+						feature.attributes.time_stamp = timestamp;
+						feature.state = OpenLayers.State.UPDATE;
+						feature.attributes.__MODIFIED__ = true;
+					});
+				}
+
+				// if (f.attributes.site_id === null && newSiteName !== '') {
+				// 	// no site_id set,
+				// 	if (MASSGIS.sites_to_site_id_hash[f.attributes.site_name]) {
+				// 		// if they picked an existing site_name, update the site_id accordingly
+				// 		f.attributes.site_id = MASSGIS.sites_to_site_id_hash[f.attributes.site_name];
+				// 	} else {
+				// 		// commented on purpose
+				// 		//f.attributes.site_id = 0;
+				// 	}
+				// }
 			}
 
-		} else if (origSiteName != f.attributes.site_name && newSiteName) {
-			// This is both cases B and D
-			// 1. - site_name_id is set to the existing site_name_id for the newSiteName, or else zero
-			var newSiteNameId;
-			if (origSiteName) {
-				newSiteNameId = MASSGIS.sites_to_site_name_id_hash[newSiteName] || false;
+			f.attributes.transaction_id = txId;
+			f.attributes.time_stamp = timestamp;
+			f.state = OpenLayers.State.UPDATE;
+			f.attributes.__MODIFIED__ = true;
+			MASSGIS.lyr_maf.strategies[1].save();
+
+			MASSGIS.buildAddressAutocompletes();
+			MASSGIS.renderLinkedAddresses();
+			MASSGIS.renderAddressList();
+		});
+		$('#linked_addrs').on("click", 'div[data-action="click_to_hide"]', function (e) {
+			var f = MASSGIS.linkedAddressLayer.getFeatureByFid($(this).data('fid'));
+			MASSGIS.linkedAddressLayer.removeFeatures([f]);
+		});
+		$('#linked_addrs').on("click", 'div[data-action="click_to_edit"]', function (e) {
+			e.stopPropagation();
+			var f = MASSGIS.linkedAddressLayer.getFeatureByFid($(this).data('fid'));
+			$.each(f.attributes, function (attr, value) {
+				$('#edit_' + attr) && $('#edit_' + attr).val(value);
+			});
+
+			// set up the autocomplete on the popup
+			$('#edit_street_name').autocomplete({
+				source: MASSGIS.streets_list
+			});
+
+			$('#edit_site_name').autocomplete({
+				source: MASSGIS.sites_list
+			});
+			$("#edit_popup").data("fid", $(this).data('fid'));
+			if (f.attributes.address_status == "GEOCODED" || f.attributes.address_status == "UNASSIGNED") {
+				$('#edit_site_name').attr("readonly", true);
 			} else {
-				newSiteNameId = MASSGIS.sites_to_site_name_id_hash[newSiteName] || 0;
+				$('#edit_site_name').attr("readonly", false);
 			}
-			newSiteNameId !== false && (f.attributes.site_name_id = newSiteNameId);
-
-			// this is a legit site, so go and find all the matching site_ids in the maf table and update them
-			if (f.attributes.site_id) {
-				var others = MASSGIS.lyr_maf.getFeaturesByAttribute("site_id", f.attributes.site_id);
-				if (others.length !== 0) {
-					$.each(others, function(idx, feature) {
-						feature.attributes.site_name = f.attributes.site_name;
-						newSiteNameId !== false && (feature.attributes.site_name_id = newSiteNameId);
-						if (feature.attributes.address_status != 'DELETED') {
-							feature.attributes.address_status = 'MODIFIED';
-						}
-						feature.attributes.transaction_id = txId;
-						feature.attributes.time_stamp = timestamp;
-						feature.state = OpenLayers.State.UPDATE;
-						feature.attributes.__MODIFIED__ = true;
-					});
-				}
-			}
-
-			if (origSiteName) {
-				var others = MASSGIS.lyr_maf.getFeaturesByAttribute("site_name", origSiteName);
-				if (others.length !== 0) {
-					$.each(others, function(idx, feature) {
-						feature.attributes.site_name = f.attributes.site_name;
-						newSiteNameId !== false && (feature.attributes.site_name_id = newSiteNameId);
-						if (feature.attributes.address_status != 'DELETED') {
-							feature.attributes.address_status = 'MODIFIED';
-						}
-						feature.attributes.transaction_id = txId;
-						feature.attributes.time_stamp = timestamp;
-						feature.state = OpenLayers.State.UPDATE;
-						feature.attributes.__MODIFIED__ = true;
-					});
-				}
-			}
-
-			if (f.attributes.site_id === null) {
-				// If the user edits site_name for an address record where site_id is null, populate that site_name to all records with the same address_point_id.
-				var others = MASSGIS.lyr_maf.getFeaturesByAttribute("address_point_id",f.attributes.address_point_id);
-				$.each(others, function(idx, feature) {
-					feature.attributes.site_name = f.attributes.site_name;
-					newSiteNameId !== false && (feature.attributes.site_name_id = newSiteNameId);
-					if (feature.attributes.address_status != 'DELETED') {
-						feature.attributes.address_status = 'MODIFIED';
-					}
-					feature.attributes.transaction_id = txId;
-					feature.attributes.time_stamp = timestamp;
-					feature.state = OpenLayers.State.UPDATE;
-					feature.attributes.__MODIFIED__ = true;
-				});
-			}
-
-			// if (f.attributes.site_id === null && newSiteName !== '') {
-			// 	// no site_id set,
-			// 	if (MASSGIS.sites_to_site_id_hash[f.attributes.site_name]) {
-			// 		// if they picked an existing site_name, update the site_id accordingly
-			// 		f.attributes.site_id = MASSGIS.sites_to_site_id_hash[f.attributes.site_name];
-			// 	} else {
-			// 		// commented on purpose
-			// 		//f.attributes.site_id = 0;
-			// 	}
-			// }
-		}
-
-		f.attributes.transaction_id = txId;
-		f.attributes.time_stamp = timestamp;
-		f.state = OpenLayers.State.UPDATE;
-		f.attributes.__MODIFIED__ = true;
-		MASSGIS.lyr_maf.strategies[1].save();
-
-		MASSGIS.buildAddressAutocompletes();
-		MASSGIS.renderLinkedAddresses();
-		MASSGIS.renderAddressList();
-	});
-	$('#linked_addrs').on("click",'div[data-action="click_to_hide"]',function(e) {
-		var f = MASSGIS.linkedAddressLayer.getFeatureByFid($(this).data('fid'));
-		MASSGIS.linkedAddressLayer.removeFeatures([f]);
-	});
-	$('#linked_addrs').on("click",'div[data-action="click_to_edit"]',function(e) {
-		e.stopPropagation();
-		var f = MASSGIS.linkedAddressLayer.getFeatureByFid($(this).data('fid'));
-		$.each(f.attributes, function(attr, value) {
-			$('#edit_' + attr) && $('#edit_' + attr).val(value);
+			$("#edit_popup").popup().popup("open");
 		});
 
-		// set up the autocomplete on the popup
-		$('#edit_street_name').autocomplete({
-			source: MASSGIS.streets_list
-		});
-
-		$('#edit_site_name').autocomplete({
-			source: MASSGIS.sites_list
-		});
-		$("#edit_popup").data("fid",$(this).data('fid'));
-		if (f.attributes.address_status == "GEOCODED" || f.attributes.address_status == "UNASSIGNED") {
-			$('#edit_site_name').attr("readonly",true);
-		} else {
-			$('#edit_site_name').attr("readonly",false);
-		}
-		$("#edit_popup").popup().popup("open");
-	});
-
-	$('#linked_addrs').on("click",".full_addr",function(e) {
-//		if (e.target !== this) {
-//			return;
-//		}
-		var oMAFRec = MASSGIS.linkedAddressLayer.getFeatureById($(this).data('id'));
-		if (!oMAFRec) {
-			// this gets triggered spurriously when we click on the four "action" buttons
-			return;
-		}
-		(!oMAFRec.selStatus || oMAFRec.selStatus == 'pre_selected') ? (oMAFRec.selStatus = 'selected') : (oMAFRec.selStatus = 'pre_selected');
-		//MASSGIS.checkMarkPrimary();
-		MASSGIS.renderLinkedAddresses();
-	});
-
-	$('#addr_list ul,#addr_query ul').on("click","li",function(e) {
-		//MASSGIS.checkMarkPrimary();
-		MASSGIS.map.setLayerZIndex(MASSGIS.preSelectionLayer, 6);
-		MASSGIS.map.setLayerZIndex(MASSGIS.selectionLayer, 12);
-
-		var linkedAddr = MASSGIS.linkedAddressLayer.getFeatureByFid($(this).data('fid'));
-		if (linkedAddr) {
-			alert('This address already appears in the linked addresses list.');
-		} else {
-			var mafAddr = MASSGIS.lyr_maf.getFeatureByFid($(this).data('fid'));
-			mafAddr.selStatus = 'pre_selected';
-			MASSGIS.linkedAddressLayer.addFeatures([mafAddr]);
-
-			// also get the other addresses linked to this same address_point_id
-			if (!mafAddr.attributes.address_point_id) {
-console.log("no address_point_id on this maf record");
+		$('#linked_addrs').on("click", ".full_addr", function (e) {
+			//		if (e.target !== this) {
+			//			return;
+			//		}
+			var oMAFRec = MASSGIS.linkedAddressLayer.getFeatureById($(this).data('id'));
+			if (!oMAFRec) {
+				// this gets triggered spurriously when we click on the four "action" buttons
 				return;
 			}
-
-			var otherMafAddrs = MASSGIS.lyr_maf.getFeaturesByAttribute("address_point_id",mafAddr.attributes.address_point_id);
-			var cleanOtherMafAddrs = [];
-			$.each(otherMafAddrs, function(idx, madRec) {
-				if (madRec.fid == $(this).data('fid')) {
-					return;
-				}
-				if (MASSGIS.linkedAddressLayer.getFeatureByFid(madRec.fid)) {
-					return;
-				}
-				cleanOtherMafAddrs.push(madRec);
-			});
-			MASSGIS.linkedAddressLayer.addFeatures(cleanOtherMafAddrs);
+			(!oMAFRec.selStatus || oMAFRec.selStatus == 'pre_selected') ? (oMAFRec.selStatus = 'selected') : (oMAFRec.selStatus = 'pre_selected');
+			//MASSGIS.checkMarkPrimary();
 			MASSGIS.renderLinkedAddresses();
+		});
 
-			var zoomToAddr = true;
-			if (MASSGIS.selectionLayer.features.length > 0 || MASSGIS.preSelectionLayer.features.length > 0) {
-				zoomToAddr = false;
+		$('#addr_list ul,#addr_query ul').on("click", "li", function (e) {
+			//MASSGIS.checkMarkPrimary();
+			MASSGIS.map.setLayerZIndex(MASSGIS.preSelectionLayer, 6);
+			MASSGIS.map.setLayerZIndex(MASSGIS.selectionLayer, 12);
+
+			var linkedAddr = MASSGIS.linkedAddressLayer.getFeatureByFid($(this).data('fid'));
+			if (linkedAddr) {
+				alert('This address already appears in the linked addresses list.');
+			} else {
+				var mafAddr = MASSGIS.lyr_maf.getFeatureByFid($(this).data('fid'));
+				mafAddr.selStatus = 'pre_selected';
+				MASSGIS.linkedAddressLayer.addFeatures([mafAddr]);
+
+				// also get the other addresses linked to this same address_point_id
+				if (!mafAddr.attributes.address_point_id) {
+					console.log("no address_point_id on this maf record");
+					return;
+				}
+
+				var otherMafAddrs = MASSGIS.lyr_maf.getFeaturesByAttribute("address_point_id", mafAddr.attributes.address_point_id);
+				var cleanOtherMafAddrs = [];
+				$.each(otherMafAddrs, function (idx, madRec) {
+					if (madRec.fid == $(this).data('fid')) {
+						return;
+					}
+					if (MASSGIS.linkedAddressLayer.getFeatureByFid(madRec.fid)) {
+						return;
+					}
+					cleanOtherMafAddrs.push(madRec);
+				});
+				MASSGIS.linkedAddressLayer.addFeatures(cleanOtherMafAddrs);
+				MASSGIS.renderLinkedAddresses();
+
+				var zoomToAddr = true;
+				if (MASSGIS.selectionLayer.features.length > 0 || MASSGIS.preSelectionLayer.features.length > 0) {
+					zoomToAddr = false;
+				}
+
+				console.log("searching for addrs with address point id " + mafAddr.attributes.address_point_id);
+				var addr_pt = MASSGIS.lyr_address_points.getFeaturesByAttribute("address_point_id", mafAddr.attributes.address_point_id);
+				$.each(addr_pt, function (idx, feature) {
+					feature.attributes.point_type !== 'GC' && feature.attributes.geographic_edit_status !== 'DELETED' && MASSGIS.preSelectionLayer.addFeatures([feature.clone()]);
+				});
+				MASSGIS.preSelectionLayer.redraw();
+
+				zoomToAddr && addr_pt.length > 0 && addr_pt[0].geometry.getBounds() && MASSGIS.map.zoomToExtent(addr_pt[0].geometry.getBounds());
 			}
+		});
+	};
 
-console.log("searching for addrs with address point id " + mafAddr.attributes.address_point_id);
-			var addr_pt = MASSGIS.lyr_address_points.getFeaturesByAttribute("address_point_id",mafAddr.attributes.address_point_id);
-			$.each(addr_pt, function(idx, feature) {
-				feature.attributes.point_type !== 'GC' && feature.attributes.geographic_edit_status !== 'DELETED' && MASSGIS.preSelectionLayer.addFeatures([feature.clone()]);
+	MASSGIS.sort_maf_features_by_street = function (obj1, obj2) {
+		var s1_num = obj1.attributes.full_number_standardized.match(/^\d*/)[0];
+		var s1_xtra = '';
+		if (s1_num != '') {
+			s1_xtra = obj1.attributes.full_number_standardized.slice(s1_num.length);
+			s1_num = s1_num * 1 + 1000000;
+		}
+		var s1 = obj1.attributes.street_name + s1_num + s1_xtra + obj1.attributes.unit + obj1.attributes.building_name;
+
+		var s2_num = obj2.attributes.full_number_standardized.match(/^\d*/)[0];
+		var s2_xtra = '';
+		if (s2_num != '') {
+			s2_xtra = obj2.attributes.full_number_standardized.slice(s2_num.length);
+			s2_num = s2_num * 1 + 1000000;
+		}
+		var s2 = obj2.attributes.street_name + s2_num + s2_xtra + obj2.attributes.unit + obj2.attributes.building_name;
+
+		return s1 > s2 ? 1 : s1 < s2 ? -1 : 0;
+	};
+
+	MASSGIS.init_datastores = function () {
+
+		MASSGIS.showModalMessage('Loading Stored Data (This may take a minute)', 'true');
+		MASSGIS.mafLoadDeferred = $.Deferred();
+		MASSGIS.addrptLoadDeferred = $.Deferred();
+		$.when(MASSGIS.mafLoadDeferred, MASSGIS.addrptLoadDeferred).then(
+			function () {
+				MASSGIS.hideModalMessage();
+				MASSGIS.init_data = true;
+				MASSGIS.init_mapExtent();
+				if (MASSGIS.lyr_maf.features.length == 0) {
+					$.mobile.showPageLoadingMsg('b', 'No addresses have been synced to this device.  Click on the Settings icon and download MSAG Community records.', 'true');
+				}
+			}
+		);
+		if (!MASSGIS.lyr_maf) {
+			MASSGIS.lyr_maf = new OpenLayers.Layer.IndexedVector("Master Address File", {
+				strategies: [new OpenLayers.Strategy.Fixed(), new OpenLayers.Strategy.Save({ auto: false })],
+				eventListeners: {
+					featureremoved: function (obj) {
+						MASSGIS.settings_updateUI();
+					},
+					featureadded: function (obj) {
+						//obj.feature.attributes.street_name = obj.feature.attributes.street_name_id + "";
+						MASSGIS.settings_updateUI();
+						delete obj.feature.data;
+						obj.feature.data = obj.feature.attributes;
+					},
+					"loadstart": function () {
+						console.log("started loading master address file");
+					},
+					"loadend": function () {
+						console.log("finished loading master address file");
+						MASSGIS.mafLoadDeferred.resolve();
+						MASSGIS.lyr_maf.features = MASSGIS.lyr_maf.features.sort(MASSGIS.sort_maf_features_by_street);
+						MASSGIS.renderAddressList();
+						MASSGIS.buildAddressAutocompletes();
+					}
+				},
+				indexes: { "address_point_id": {} },
+				projection: MASSGIS.map.getProjection(),
+				protocol: new OpenLayers.Protocol.SQL.WebSQL({ databaseName: 'mgis_addrs', tableName: 'maf', initialSize: 1 * 1024 * 1024 })
+				, maxResolution: .001 // never draw this layer
 			});
-			MASSGIS.preSelectionLayer.redraw();
-
-			zoomToAddr && addr_pt.length > 0 && addr_pt[0].geometry.getBounds() && MASSGIS.map.zoomToExtent(addr_pt[0].geometry.getBounds());
-		}
-	});
-};
-
-MASSGIS.sort_maf_features_by_street = function(obj1, obj2) {
-  var s1_num = obj1.attributes.full_number_standardized.match(/^\d*/)[0];
-  var s1_xtra = '';
-  if (s1_num != '') {
-	s1_xtra = obj1.attributes.full_number_standardized.slice(s1_num.length);
-	s1_num = s1_num * 1 + 1000000;
-  }
-  var s1 = obj1.attributes.street_name + s1_num + s1_xtra + obj1.attributes.unit + obj1.attributes.building_name;
-
-  var s2_num = obj2.attributes.full_number_standardized.match(/^\d*/)[0];
-  var s2_xtra = '';
-  if (s2_num != '') {
-	s2_xtra = obj2.attributes.full_number_standardized.slice(s2_num.length);
-	s2_num = s2_num * 1 + 1000000;
-  }
-  var s2 = obj2.attributes.street_name + s2_num + s2_xtra + obj2.attributes.unit + obj2.attributes.building_name;
-
-  return s1 > s2 ? 1 : s1 < s2 ? -1 : 0;
-};
-
-MASSGIS.init_datastores = function() {
-
-	MASSGIS.showModalMessage('Loading Stored Data (This may take a minute)','true');
-	MASSGIS.mafLoadDeferred = $.Deferred();
-	MASSGIS.addrptLoadDeferred = $.Deferred();
-	$.when(MASSGIS.mafLoadDeferred, MASSGIS.addrptLoadDeferred).then(
-		function() {
-			MASSGIS.hideModalMessage();
-			MASSGIS.init_data = true;
-			MASSGIS.init_mapExtent();
-			if (MASSGIS.lyr_maf.features.length == 0) {
-				$.mobile.showPageLoadingMsg('b','No addresses have been synced to this device.  Click on the Settings icon and download MSAG Community records.','true');
-			}
-		}
-	);
-	if (!MASSGIS.lyr_maf) {
-		MASSGIS.lyr_maf = new OpenLayers.Layer.IndexedVector("Master Address File", {
-			strategies: [ new OpenLayers.Strategy.Fixed(), new OpenLayers.Strategy.Save({auto: false}) ],
-			eventListeners: {
-				featureremoved: function(obj) {
-					MASSGIS.settings_updateUI();
-				},
-				featureadded: function(obj) {
-					//obj.feature.attributes.street_name = obj.feature.attributes.street_name_id + "";
-					MASSGIS.settings_updateUI();
-					delete obj.feature.data;
-					obj.feature.data = obj.feature.attributes;
-				},
-				"loadstart":function() {
-					console.log("started loading master address file");
-				},
-				"loadend": function() {
-					console.log("finished loading master address file");
-					MASSGIS.mafLoadDeferred.resolve();
+			MASSGIS.lyr_maf.strategies[1].events.on({
+				"success": function () {
 					MASSGIS.lyr_maf.features = MASSGIS.lyr_maf.features.sort(MASSGIS.sort_maf_features_by_street);
-					MASSGIS.renderAddressList();
-					MASSGIS.buildAddressAutocompletes();
+					MASSGIS.lyr_maf.saveDeferred.resolve();
 				}
+			});
+			MASSGIS.map.addLayer(MASSGIS.lyr_maf);
+			MASSGIS.lyr_maf.saveDeferred = $.Deferred();
+
+			MASSGIS.lyr_maf_constrained = new OpenLayers.Layer.IndexedVector("Master Address File constrained by proximity or query");
+		} else {
+			window.setTimeout(function () {
+				MASSGIS.lyr_maf.strategies[0].load();
+			}, 200);
+		}
+
+		var style = new OpenLayers.Style(
+			// the first argument is a base symbolizer
+			// all other symbolizers in rules will extend this one
+			{
+				//"label" : "${ST_NUM}",
+				//"label" : "${get_linked_st_num}",
+				"label": "${get_label}",
+				"labelAlign": "lm",
+				"labelXOffset": 0,
+				"labelYOffset": -10,
+				"fontColor": "#333",
+				"labelOutlineColor": "#fff",
+				"labelOutlineWidth": 5,
+				"labelOutlineOpacity": 0.7,
+				"pointRadius": 13,
+				"externalGraphic": "img/${status_color}_${type_icon}.PNG",
+				"display": "${get_display}"
 			},
-			indexes: {"address_point_id":{}},
-			projection: MASSGIS.map.getProjection(),
-			protocol: new OpenLayers.Protocol.SQL.WebSQL({databaseName: 'mgis_addrs', tableName: 'maf', initialSize: 1*1024*1024})
-			,maxResolution : .001 // never draw this layer
-		});
-		MASSGIS.lyr_maf.strategies[1].events.on({
-			"success": function() {
-				MASSGIS.lyr_maf.features = MASSGIS.lyr_maf.features.sort(MASSGIS.sort_maf_features_by_street);
-				MASSGIS.lyr_maf.saveDeferred.resolve();
-			}
-		});
-		MASSGIS.map.addLayer(MASSGIS.lyr_maf);
-		MASSGIS.lyr_maf.saveDeferred = $.Deferred();
-
-		MASSGIS.lyr_maf_constrained = new OpenLayers.Layer.IndexedVector("Master Address File constrained by proximity or query");
-	} else {
-		window.setTimeout( function() {
-			MASSGIS.lyr_maf.strategies[0].load();
-		}, 200);
-	}
-
-	var style = new OpenLayers.Style(
-		// the first argument is a base symbolizer
-		// all other symbolizers in rules will extend this one
-		{
-			//"label" : "${ST_NUM}",
-			//"label" : "${get_linked_st_num}",
-			"label" : "${get_label}",
-			"labelAlign" : "lm",
-			"labelXOffset" : 0,
-			"labelYOffset" : -10,
-			"fontColor" : "#333",
-			"labelOutlineColor" : "#fff",
-			"labelOutlineWidth" : 5,
-			"labelOutlineOpacity" : 0.7,
-			"pointRadius" : 13,
-			"externalGraphic" : "img/${status_color}_${type_icon}.PNG",
-			"display" : "${get_display}"
-		},
-		// the second argument will include all rules
-		{
-			context: {
-				get_label: function(f) {
-					return f.attributes.label_text === null ? "" : f.attributes.label_text;
-				},
-				get_display : function(f) {
-					return (f.attributes.status_color == 'NONE' || f.attributes.type_icon == 'NONE') ? 'none' : 'visible';
-				}
-			},
-			rules: [
-			]
-		}
-	);
-
-	if (!MASSGIS.lyr_address_points) {
-		MASSGIS.lyr_address_points = new OpenLayers.Layer.SpatialIndexedVector("Address Points", {
-			strategies: [ new OpenLayers.Strategy.Fixed() , new OpenLayers.Strategy.Save({auto: false}) ]
-			,eventListeners: {
-				"featureremoved": function(obj) {
-					MASSGIS.settings_updateUI();
-				},
-				"featureadded": function(obj) {
-	//				if (obj.feature.attributes) {
-	//					obj.feature.attributes['linked_st_num'] = MASSGIS.lyr_address_points.draw_linked_st_num;
-	//				}
-					MASSGIS.settings_updateUI();
-				},
-				"loadstart" : function() {
-					console.log("start loading address points");
-				},
-				"loadend": function() {
-					console.log("finished loading address points");
-					MASSGIS.addrptLoadDeferred.resolve();
-				}
-			}
-			,projection: "EPSG:900913"
-			,protocol: new OpenLayers.Protocol.SQL.WebSQL({databaseName: 'mgis_addrs', tableName: 'address_points', initialSize: 1*1024*1024})
-			,styleMap: new OpenLayers.StyleMap(style)
-			,renderers: ['Canvas']
-			,maxResolution : 2
-			,draw_linked_st_num : function(f, p) {
-				var features = MASSGIS.lyr_maf.getFeaturesByAttribute("address_point_id",f.attributes.address_point_id);
-				if (features.length > 0) {
-					var f = _.sortBy(features,function(f){return 1000000 + f.attributes.full_number_standardized * 1});
-					var n = _.uniq(_.map(f,function(val,key){return val.attributes.full_number_standardized}));
-					if (n.length == 1) {
-						return n[0];
+			// the second argument will include all rules
+			{
+				context: {
+					get_label: function (f) {
+						return f.attributes.label_text === null ? "" : f.attributes.label_text;
+					},
+					get_display: function (f) {
+						return (f.attributes.status_color == 'NONE' || f.attributes.type_icon == 'NONE') ? 'none' : 'visible';
 					}
-					else {
-						return n[0] + '-' + n[n.length - 1];
+				},
+				rules: [
+				]
+			}
+		);
+
+		if (!MASSGIS.lyr_address_points) {
+			MASSGIS.lyr_address_points = new OpenLayers.Layer.SpatialIndexedVector("Address Points", {
+				strategies: [new OpenLayers.Strategy.Fixed(), new OpenLayers.Strategy.Save({ auto: false })]
+				, eventListeners: {
+					"featureremoved": function (obj) {
+						MASSGIS.settings_updateUI();
+					},
+					"featureadded": function (obj) {
+						//				if (obj.feature.attributes) {
+						//					obj.feature.attributes['linked_st_num'] = MASSGIS.lyr_address_points.draw_linked_st_num;
+						//				}
+						MASSGIS.settings_updateUI();
+					},
+					"loadstart": function () {
+						console.log("start loading address points");
+					},
+					"loadend": function () {
+						console.log("finished loading address points");
+						MASSGIS.addrptLoadDeferred.resolve();
 					}
-				} else {
-					return "";
 				}
-			}
-			,indexes: {"address_point_id": {}}
-			,spatialIndex: new RTree()
-		});
-
-		MASSGIS.lyr_address_points.strategies[1].events.on({
-			"success": function() {
-				MASSGIS.lyr_address_points.saveDeferred.resolve();
-			}
-		});
-
-		MASSGIS.map.addLayer(MASSGIS.lyr_address_points);
-
-		MASSGIS.lyr_address_points.saveDeferred = $.Deferred();
-	} else {
-		window.setTimeout( function() {
-			MASSGIS.lyr_address_points.strategies[0].load();
-		},200);
-	}
-
-	MASSGIS.settings_updateUI();
-};
-
-MASSGIS.addrptsWriter = new OpenLayers.Format.WFST.v1_0_0({
-	"featureNS" : "http://massgis.state.ma.us/featuretype",
-	//"featureNS" : "http://www.mapsonline.net/peopleforms",
-	"featurePrefix" : "massgis",
-	"featureType" : "MAD.MAD_ADDRESS_POINTM_CHANGES",
-	"geometryName" : "shape"
-});
-
-MASSGIS.mafWriter = new OpenLayers.Format.WFST.v1_0_0({
-	"featureNS" : "http://massgis.state.ma.us/featuretype",
-	//"featureNS" : "http://www.mapsonline.net/peopleforms",
-	"featurePrefix" : "massgis",
-	"featureType" : "MAD.MAD_MASTER_ADDRESS_CHANGES",
-	"geometryName" : "shape"
-});
-
-MASSGIS.wfstFilterGenerator = function(feature, options) {
-	return new OpenLayers.Filter.Comparison(
-		{
-			type: OpenLayers.Filter.Comparison.EQUAL_TO,
-			property:"address_point_id",
-			value: feature.attributes.address_point_id
-		}
-	);
-};
-
-MASSGIS.check_recs_to_submit = function() {
-	var mafSubmit = [];
-	var edit_date = '';
-	$.each(MASSGIS.lyr_maf.features, function(idx, feature) {
-		if (feature.attributes.__MODIFIED__) {
-			// insert the a/d/m records
-			var f = feature.clone();
-			f.state = OpenLayers.State.INSERT;
-			if (f.attributes.address_status == 'DELETED') {
-				f.attributes.address_point_id = f.attributes.address_point_id ? f.attributes.address_point_id.replace("_D","") : null;
-			}
-			f.attributes.last_edit_by = MASSGIS.username;
-			f.attributes.last_edit_date = edit_date;
-
-			delete f.attributes.__MODIFIED__;
-			delete f.attributes.bbox;
-			mafSubmit.push(f);
-		}
-	});
-
-	var addrSubmit = [];
-	$.each(MASSGIS.lyr_address_points.features, function(idx, feature) {
-		if (feature.attributes.__MODIFIED__) {
-			// insert the a/d/m records
-			var f = feature.clone();
-			f.state = OpenLayers.State.INSERT;
-			f.attributes.last_edit_by = MASSGIS.username;
-			f.attributes.last_edit_date = edit_date;
-
-			delete f.attributes.__MODIFIED__;
-			delete f.attributes.bbox;
-			addrSubmit.push(f);
-		}
-	});
-
-	console.log("MAF submissions", mafSubmit);
-	console.log("ADDR_PT submissions", addrSubmit);
-;}
-
-MASSGIS.submit_maf_records = function() {
-	//build a list of our modified lyr_maf data
-	var d = new Date();
-	var edit_date = d.getFullYear() + ("0" + (d.getMonth() + 1)).slice(-2) + ("0" + d.getDate()).slice(-2);
-	mafSubmitFeatures = [];
-	var bSaveChanges = false;
-	$.each(MASSGIS.lyr_maf.features, function(idx, feature) {
-		if (feature.attributes.__MODIFIED__) {
-			if (!feature.attributes.ma_chng_uid) {
-				//feature.attributes.ma_chng_uid = "ma_chng_uid_" + MASSGIS.generateTXId();
-				feature.attributes.ma_chng_uid = feature.attributes.transaction_id + "_" + MASSGIS.generateTXId();
-				feature.state = OpenLayers.State.UPDATE;
-				bSaveChanges = true;
-			}
-			// insert the a/d/m records
-			var f = feature.clone();
-			f.state = OpenLayers.State.INSERT;
-			if (f.attributes.address_status == 'DELETED') {
-				f.attributes.address_point_id = f.attributes.address_point_id ? f.attributes.address_point_id.replace("_D","") : null;
-			}
-			if (("" + f.attributes.master_address_id).indexOf('NEW-') !== -1) {
-				f.attributes.master_address_id = 0;
-			}
-			f.attributes.last_edit_by = MASSGIS.username;
-			f.attributes.last_edit_date = edit_date;
-
-			delete f.attributes.__MODIFIED__;
-			delete f.attributes.bbox;
-			mafSubmitFeatures.push(f);
-		}
-	});
-
-	if (bSaveChanges) {
-		MASSGIS.lyr_maf.strategies[1].save();
-	}
-
-	if (mafSubmitFeatures.length === 0) {
-		return false;
-	}
-
-
-	var maf_wfstTransactionStr = MASSGIS.mafWriter.write(mafSubmitFeatures, { 'filterGenerator' : MASSGIS.wfstFilterGenerator });
-	console.log(maf_wfstTransactionStr);
-
-	MASSGIS.showModalMessage('Syncing Address Data to Server',true);
-	var errorCount = 0;
-	var sendUpdates = function() {
-		if (errorCount > 5) {
-			alert('After trying 5 times, the server was unable to accept your Master Address List updates.  Please contact Sienna Svob at sienna.svob@state.ma.us or (617) 388-5723.');
-			MASSGIS.hideModalMessage();
-			return;
-		}
-		$.ajax({
-			type: "post",
-			url: MASSGIS.proxy,
-			//url: "/fdc/dummy_response.php",
-			contentType: "text/xml",
-			data: maf_wfstTransactionStr,
-			dataType: "xml",
-			processData: false,
-			success: function( response ) {
-				console.log(response);
-				if (!response || response.getElementsByTagName("SUCCESS").length == 0) {
-					// failed, wait and try again?
-					$.mobile.showPageLoadingMsg('b','ArcSDE failure syncing address data.  Trying again.',true);
-					errorCount++;
-					//window.setTimeout(sendUpdates, 2500);
-					MASSGIS.hideModalMessage();
-					return;
-				} else {
-					MASSGIS.hideModalMessage();
-					$.each(MASSGIS.lyr_maf.features, function(idx, feature) {
-						if (feature.attributes.__MODIFIED__) {
-							// clean up this record
-							delete feature.attributes.__MODIFIED__;
-							delete feature.attributes.ma_chng_uid;
-							feature.state = OpenLayers.State.UPDATE;
+				, projection: "EPSG:900913"
+				, protocol: new OpenLayers.Protocol.SQL.WebSQL({ databaseName: 'mgis_addrs', tableName: 'address_points', initialSize: 1 * 1024 * 1024 })
+				, styleMap: new OpenLayers.StyleMap(style)
+				, renderers: ['Canvas']
+				, maxResolution: 2
+				, draw_linked_st_num: function (f, p) {
+					var features = MASSGIS.lyr_maf.getFeaturesByAttribute("address_point_id", f.attributes.address_point_id);
+					if (features.length > 0) {
+						var f = _.sortBy(features, function (f) { return 1000000 + f.attributes.full_number_standardized * 1 });
+						var n = _.uniq(_.map(f, function (val, key) { return val.attributes.full_number_standardized }));
+						if (n.length == 1) {
+							return n[0];
 						}
-					});
-					MASSGIS.lyr_maf.strategies[1].save();
+						else {
+							return n[0] + '-' + n[n.length - 1];
+						}
+					} else {
+						return "";
+					}
 				}
-				// should we clear the data off of the unit now?
-				//$('#settings_clear').click();
-			},
-			error: function () {
-				$.mobile.showPageLoadingMsg('b','Server failure syncing address data (Try # ' + (errorCount + 1) + ').  Trying again.',true);
-				errorCount++;
-				//window.setTimeout(sendUpdates, 2500);
-			}
-		});
+				, indexes: { "address_point_id": {} }
+				, spatialIndex: new RTree()
+			});
+
+			MASSGIS.lyr_address_points.strategies[1].events.on({
+				"success": function () {
+					MASSGIS.lyr_address_points.saveDeferred.resolve();
+				}
+			});
+
+			MASSGIS.map.addLayer(MASSGIS.lyr_address_points);
+
+			MASSGIS.lyr_address_points.saveDeferred = $.Deferred();
+		} else {
+			window.setTimeout(function () {
+				MASSGIS.lyr_address_points.strategies[0].load();
+			}, 200);
+		}
+
+		MASSGIS.settings_updateUI();
 	};
-	sendUpdates();
 
-};
-
-MASSGIS.webMerc = new OpenLayers.Projection("EPSG:900913");
-MASSGIS.statePlane = new OpenLayers.Projection("EPSG:26986");
-MASSGIS.submit_address_points = function() {
-	//build a list of our modified lyr_address_points data
-	var d = new Date();
-	var edit_date = d.getFullYear() + ("0" + (d.getMonth() + 1)).slice(-2) + ("0" + d.getDate()).slice(-2);
-	addrSubmitFeatures = [];
-	var bSaveChanges = false;
-	$.each(MASSGIS.lyr_address_points.features, function(idx, feature) {
-		if (feature.attributes.__MODIFIED__) {
-			if (!feature.attributes.ap_chng_uid) {
-				//feature.attributes.ap_chng_uid = "ap_chng_uid_" + MASSGIS.generateTXId();
-				feature.attributes.ap_chng_uid = feature.attributes.transaction_id + "_" + MASSGIS.generateTXId();
-				feature.state = OpenLayers.State.UPDATE;
-				bSaveChanges = true;
-			}
-		}
-		if (feature.attributes.__MODIFIED__) {
-			// insert the a/d/m records
-			var f = feature.clone();
-
-			f.geometry.transform(MASSGIS.webMerc, MASSGIS.statePlane);
-			f.attributes.last_edit_by = MASSGIS.username;
-			f.attributes.last_edit_date = edit_date;
-			f.state = OpenLayers.State.INSERT;
-
-			delete f.attributes.__MODIFIED__;
-			delete f.attributes.bbox;
-			addrSubmitFeatures.push(f);
-		}
+	MASSGIS.addrptsWriter = new OpenLayers.Format.WFST.v1_0_0({
+		"featureNS": "http://massgis.state.ma.us/featuretype",
+		//"featureNS" : "http://www.mapsonline.net/peopleforms",
+		"featurePrefix": "massgis",
+		"featureType": "MAD.MAD_ADDRESS_POINTM_CHANGES",
+		"geometryName": "shape"
 	});
 
-	if (bSaveChanges) {
-		MASSGIS.lyr_address_points.strategies[1].save();
+	MASSGIS.mafWriter = new OpenLayers.Format.WFST.v1_0_0({
+		"featureNS": "http://massgis.state.ma.us/featuretype",
+		//"featureNS" : "http://www.mapsonline.net/peopleforms",
+		"featurePrefix": "massgis",
+		"featureType": "MAD.MAD_MASTER_ADDRESS_CHANGES",
+		"geometryName": "shape"
+	});
+
+	MASSGIS.wfstFilterGenerator = function (feature, options) {
+		return new OpenLayers.Filter.Comparison(
+			{
+				type: OpenLayers.Filter.Comparison.EQUAL_TO,
+				property: "address_point_id",
+				value: feature.attributes.address_point_id
+			}
+		);
+	};
+
+	MASSGIS.check_recs_to_submit = function () {
+		var mafSubmit = [];
+		var edit_date = '';
+		$.each(MASSGIS.lyr_maf.features, function (idx, feature) {
+			if (feature.attributes.__MODIFIED__) {
+				// insert the a/d/m records
+				var f = feature.clone();
+				f.state = OpenLayers.State.INSERT;
+				if (f.attributes.address_status == 'DELETED') {
+					f.attributes.address_point_id = f.attributes.address_point_id ? f.attributes.address_point_id.replace("_D", "") : null;
+				}
+				f.attributes.last_edit_by = MASSGIS.username;
+				f.attributes.last_edit_date = edit_date;
+
+				delete f.attributes.__MODIFIED__;
+				delete f.attributes.bbox;
+				mafSubmit.push(f);
+			}
+		});
+
+		var addrSubmit = [];
+		$.each(MASSGIS.lyr_address_points.features, function (idx, feature) {
+			if (feature.attributes.__MODIFIED__) {
+				// insert the a/d/m records
+				var f = feature.clone();
+				f.state = OpenLayers.State.INSERT;
+				f.attributes.last_edit_by = MASSGIS.username;
+				f.attributes.last_edit_date = edit_date;
+
+				delete f.attributes.__MODIFIED__;
+				delete f.attributes.bbox;
+				addrSubmit.push(f);
+			}
+		});
+
+		console.log("MAF submissions", mafSubmit);
+		console.log("ADDR_PT submissions", addrSubmit);
+		;
 	}
 
-	if (addrSubmitFeatures.length === 0) {
-		return;
-	}
+	MASSGIS.submit_maf_records = function () {
+		//build a list of our modified lyr_maf data
+		var d = new Date();
+		var edit_date = d.getFullYear() + ("0" + (d.getMonth() + 1)).slice(-2) + ("0" + d.getDate()).slice(-2);
+		mafSubmitFeatures = [];
+		var bSaveChanges = false;
+		$.each(MASSGIS.lyr_maf.features, function (idx, feature) {
+			if (feature.attributes.__MODIFIED__) {
+				if (!feature.attributes.ma_chng_uid) {
+					//feature.attributes.ma_chng_uid = "ma_chng_uid_" + MASSGIS.generateTXId();
+					feature.attributes.ma_chng_uid = feature.attributes.transaction_id + "_" + MASSGIS.generateTXId();
+					feature.state = OpenLayers.State.UPDATE;
+					bSaveChanges = true;
+				}
+				// insert the a/d/m records
+				var f = feature.clone();
+				f.state = OpenLayers.State.INSERT;
+				if (f.attributes.address_status == 'DELETED') {
+					f.attributes.address_point_id = f.attributes.address_point_id ? f.attributes.address_point_id.replace("_D", "") : null;
+				}
+				if (("" + f.attributes.master_address_id).indexOf('NEW-') !== -1) {
+					f.attributes.master_address_id = 0;
+				}
+				f.attributes.last_edit_by = MASSGIS.username;
+				f.attributes.last_edit_date = edit_date;
 
-	var addr_wfstTransactionStr = MASSGIS.addrptsWriter.write(addrSubmitFeatures, { 'filterGenerator' : MASSGIS.wfstFilterGenerator });
-	console.log(addr_wfstTransactionStr);
+				delete f.attributes.__MODIFIED__;
+				delete f.attributes.bbox;
+				mafSubmitFeatures.push(f);
+			}
+		});
 
-	MASSGIS.showModalMessage('Syncing Address Data to Server',true);
-	var errorCount = 0;
-	var sendUpdates = function() {
-		if (errorCount > 5) {
-			alert('After trying 5 times, the server was unable to accept your Address Point updates.  Please contact Sienna Svob at sienna.svob@state.ma.us or (617) 388-5723.');
-			MASSGIS.hideModalMessage();
-			return;
+		if (bSaveChanges) {
+			MASSGIS.lyr_maf.strategies[1].save();
 		}
-		$.ajax({
-			type: "post",
-			url: MASSGIS.proxy,
-			//url: "/fdc/dummy_response.php",
-			contentType: "text/xml",
-			data: addr_wfstTransactionStr,
-			dataType: "xml",
-			processData: false,
-			success: function( response ) {
-				console.log(response);
-				if (!response || response.getElementsByTagName("SUCCESS").length == 0) {
-					// failed, wait and try again?
-					$.mobile.showPageLoadingMsg('b','ArcSDE failure syncing address data.  Trying again.',true);
+
+		if (mafSubmitFeatures.length === 0) {
+			return false;
+		}
+
+
+		var maf_wfstTransactionStr = MASSGIS.mafWriter.write(mafSubmitFeatures, { 'filterGenerator': MASSGIS.wfstFilterGenerator });
+		console.log(maf_wfstTransactionStr);
+
+		MASSGIS.showModalMessage('Syncing Address Data to Server', true);
+		var errorCount = 0;
+		var sendUpdates = function () {
+			if (errorCount > 5) {
+				alert('After trying 5 times, the server was unable to accept your Master Address List updates.  Please contact Sienna Svob at sienna.svob@state.ma.us or (617) 388-5723.');
+				MASSGIS.hideModalMessage();
+				return;
+			}
+			$.ajax({
+				type: "post",
+				url: MASSGIS.proxy,
+				//url: "/fdc/dummy_response.php",
+				contentType: "text/xml",
+				data: maf_wfstTransactionStr,
+				dataType: "xml",
+				processData: false,
+				success: function (response) {
+					console.log(response);
+					if (!response || response.getElementsByTagName("SUCCESS").length == 0) {
+						// failed, wait and try again?
+						$.mobile.showPageLoadingMsg('b', 'ArcSDE failure syncing address data.  Trying again.', true);
+						errorCount++;
+						//window.setTimeout(sendUpdates, 2500);
+						MASSGIS.hideModalMessage();
+						return;
+					} else {
+						MASSGIS.hideModalMessage();
+						$.each(MASSGIS.lyr_maf.features, function (idx, feature) {
+							if (feature.attributes.__MODIFIED__) {
+								// clean up this record
+								delete feature.attributes.__MODIFIED__;
+								delete feature.attributes.ma_chng_uid;
+								feature.state = OpenLayers.State.UPDATE;
+							}
+						});
+						MASSGIS.lyr_maf.strategies[1].save();
+					}
+					// should we clear the data off of the unit now?
+					//$('#settings_clear').click();
+				},
+				error: function () {
+					$.mobile.showPageLoadingMsg('b', 'Server failure syncing address data (Try # ' + (errorCount + 1) + ').  Trying again.', true);
 					errorCount++;
 					//window.setTimeout(sendUpdates, 2500);
-					alert('Please update spreadsheet with submission time and wait to clear cache until cell turns green. If you have questions email Michael.Mulqueen@mass.gov');
-					MASSGIS.hideModalMessage();
-					return;
-				} else {
-					$.each(MASSGIS.lyr_address_points.features, function(idx, feature) {
-						if (feature.attributes.__MODIFIED__) {
-							// clean up this record
-							delete feature.attributes.__MODIFIED__;
-							delete feature.attributes.ap_chng_uid;
-							feature.state = OpenLayers.State.UPDATE;
-						}
+				}
+			});
+		};
+		sendUpdates();
+
+	};
+
+	MASSGIS.webMerc = new OpenLayers.Projection("EPSG:900913");
+	MASSGIS.statePlane = new OpenLayers.Projection("EPSG:26986");
+	MASSGIS.submit_address_points = function () {
+		//build a list of our modified lyr_address_points data
+		var d = new Date();
+		var edit_date = d.getFullYear() + ("0" + (d.getMonth() + 1)).slice(-2) + ("0" + d.getDate()).slice(-2);
+		addrSubmitFeatures = [];
+		var bSaveChanges = false;
+		$.each(MASSGIS.lyr_address_points.features, function (idx, feature) {
+			if (feature.attributes.__MODIFIED__) {
+				if (!feature.attributes.ap_chng_uid) {
+					//feature.attributes.ap_chng_uid = "ap_chng_uid_" + MASSGIS.generateTXId();
+					feature.attributes.ap_chng_uid = feature.attributes.transaction_id + "_" + MASSGIS.generateTXId();
+					feature.state = OpenLayers.State.UPDATE;
+					bSaveChanges = true;
+				}
+			}
+			if (feature.attributes.__MODIFIED__) {
+				// insert the a/d/m records
+				var f = feature.clone();
+
+				f.geometry.transform(MASSGIS.webMerc, MASSGIS.statePlane);
+				f.attributes.last_edit_by = MASSGIS.username;
+				f.attributes.last_edit_date = edit_date;
+				f.state = OpenLayers.State.INSERT;
+
+				delete f.attributes.__MODIFIED__;
+				delete f.attributes.bbox;
+				addrSubmitFeatures.push(f);
+			}
+		});
+
+		if (bSaveChanges) {
+			MASSGIS.lyr_address_points.strategies[1].save();
+		}
+
+		if (addrSubmitFeatures.length === 0) {
+			return;
+		}
+
+		var addr_wfstTransactionStr = MASSGIS.addrptsWriter.write(addrSubmitFeatures, { 'filterGenerator': MASSGIS.wfstFilterGenerator });
+		console.log(addr_wfstTransactionStr);
+
+		MASSGIS.showModalMessage('Syncing Address Data to Server', true);
+		var errorCount = 0;
+		var sendUpdates = function () {
+			if (errorCount > 5) {
+				alert('After trying 5 times, the server was unable to accept your Address Point updates.  Please contact Sienna Svob at sienna.svob@state.ma.us or (617) 388-5723.');
+				MASSGIS.hideModalMessage();
+				return;
+			}
+			$.ajax({
+				type: "post",
+				url: MASSGIS.proxy,
+				//url: "/fdc/dummy_response.php",
+				contentType: "text/xml",
+				data: addr_wfstTransactionStr,
+				dataType: "xml",
+				processData: false,
+				success: function (response) {
+					console.log(response);
+					if (!response || response.getElementsByTagName("SUCCESS").length == 0) {
+						// failed, wait and try again?
+						$.mobile.showPageLoadingMsg('b', 'ArcSDE failure syncing address data.  Trying again.', true);
+						errorCount++;
+						//window.setTimeout(sendUpdates, 2500);
+						alert('Please update spreadsheet with submission time and wait to clear cache until cell turns green. If you have questions email Michael.Mulqueen@mass.gov');
+						MASSGIS.hideModalMessage();
+						return;
+					} else {
+						$.each(MASSGIS.lyr_address_points.features, function (idx, feature) {
+							if (feature.attributes.__MODIFIED__) {
+								// clean up this record
+								delete feature.attributes.__MODIFIED__;
+								delete feature.attributes.ap_chng_uid;
+								feature.state = OpenLayers.State.UPDATE;
+							}
+						});
+						MASSGIS.lyr_address_points.strategies[1].save();
+						MASSGIS.hideModalMessage();
+					}
+					// should we clear the data off of the unit now?
+					//$('#settings_clear').click();
+				},
+				error: function () {
+					$.mobile.showPageLoadingMsg('b', 'Server failure syncing address data (Try # ' + (errorCount + 1) + ').  Trying again.', true);
+					errorCount++;
+					//window.setTimeout(sendUpdates, 2500);
+				}
+			});
+		};
+		sendUpdates();
+	};
+
+	MASSGIS.sync_address_points_fail_count = 0;
+	MASSGIS.sync_address_points = function () {
+		$('#linked_addrs_buttons #clear_button').trigger('click');
+
+		//load all data from WFS on server, store into WebSQL vector database
+		return $.jsonp(
+			{
+				//url: "http://www.mapsonline.net/geoserver-2.1.1/wfs",
+				//url: 'https://wsgw.mass.gov/geoserver/wfs',
+				//url: 'http://10.202.25.161:8080/geoserver/wfs',
+				url: 'https://gis-prod.digital.mass.gov/geoserver/wfs',
+				//url: 'http://10.202.26.28/geoserver/wfs',
+				data: {
+					"request": "getfeature",
+					//"typename" : "massgis:massgis_rockportma_address_pointm",
+					"typename": 'massgis:MAD.MAD_ADDRESS_POINTM',
+					//"outputformat" : "json",
+					"outputformat": "text/javascript",
+					"service": "WFS",
+					"version": "1.0.0",
+					"cql_filter": "community_id = '" + $('#msag_community').val() + "'",
+					"srsName": "EPSG:900913"
+				},
+				callback: "_jqjsp_" + Math.round(Math.random() * 1000000),
+				beforeSend: function (settings) {
+					settings.data.callback = null;
+					settings.data.format_options = "CALLBACK:" + settings.callback;
+				},
+				success: function (data, xhr, statusText) {
+					if (MASSGIS.dataSyncStatus == "failed") {
+						console.log("abandoning address point data-load response");
+						return;
+					}
+					if (data.features[0].id.indexOf("MAD.MAD_ADDRESS_POINTM") === -1) {
+						console.log("mis-routed jsonp response");
+						this.error();
+						return;
+					}
+					var reader = new OpenLayers.Format.GeoJSON();
+					var features = [];
+					$.each(data.features, function (idx, obj) {
+						var feature = reader.read(obj)[0];
+						feature.state = OpenLayers.State.INSERT;
+						delete feature.data;
+						features.push(feature);
 					});
+
+					MASSGIS.lyr_address_points.addFeatures(features);
+					MASSGIS.settings_updateUI();
 					MASSGIS.lyr_address_points.strategies[1].save();
-					MASSGIS.hideModalMessage();
+				},
+				"error": function () {
+					MASSGIS.dataSyncStatus = "failed";
+					console.log("failed to load address points");
+					alert("there was an error loading the address points for this area.  Please click the 'Clear Records from This Device' button, and re-download the records in this community");
 				}
-				// should we clear the data off of the unit now?
-				//$('#settings_clear').click();
-			},
-			error: function () {
-				$.mobile.showPageLoadingMsg('b','Server failure syncing address data (Try # ' + (errorCount + 1) + ').  Trying again.',true);
-				errorCount++;
-				//window.setTimeout(sendUpdates, 2500);
+			}
+		);
+
+	};
+
+	MASSGIS.sync_maf = function () {
+
+		//load all data from WFS on server, store into WebSQL vector database
+		return $.jsonp(
+			{
+				//url: "http://www.mapsonline.net/geoserver-2.1.1/wfs",
+				//url: "https://wsgw.mass.gov/geoserver/wfs",
+				//url: "http://10.202.25.161:8080/geoserver/wfs",
+				url: "https://gis-prod.digital.mass.gov/geoserver/wfs",
+				//url: "http://10.202.26.28/geoserver/wfs",
+				dataType: "jsonp",
+				data: {
+					"request": "getfeature",
+					//"typename" : "massgis:massgis_rockportma_maf_d",
+					//"typename" : "massgis:MAD.MAD_MASTER_ADDRESS_STNAME_VIEW",
+					"typename": "massgis:MAD.MADV_MASTER_ADDRESS_STNAME",
+					//"outputformat" : "json",
+					"outputformat": "text/javascript",
+					"service": "WFS",
+					"cql_filter": "community_id = '" + $('#msag_community').val() + "'",
+					"version": "1.0.0",
+					"srsName": "EPSG:900913"
+				},
+				callback: "_jqjsp_" + Math.round(Math.random() * 1000000),
+				beforeSend: function (settings) {
+					settings.data.callback = null;
+					settings.data.format_options = "CALLBACK:" + settings.callback;
+				},
+				"success": function (data, xhr, statusText) {
+					if (MASSGIS.dataSyncStatus == "failed") {
+						console.log("abandoning maf data-load response");
+						return;
+					}
+					if (data.features[0].id.indexOf("MAD.MADV_MASTER_ADDRESS_STNAME") === -1) {
+						console.log("mis-routed jsonp response");
+						this.error();
+						return;
+					}
+					var reader = new OpenLayers.Format.GeoJSON();
+					var features = [];
+					$.each(data.features, function (idx, obj) {
+						var feature = reader.read(obj)[0];
+						feature.state = OpenLayers.State.INSERT;
+						delete feature.data;
+						features.push(feature);
+					});
+
+					MASSGIS.lyr_maf.addFeatures(features);
+					MASSGIS.settings_updateUI();
+					MASSGIS.lyr_maf.strategies[1].save();
+					MASSGIS.lyr_maf.features = MASSGIS.lyr_maf.features.sort(MASSGIS.sort_maf_features_by_street);
+				},
+				"error": function () {
+					MASSGIS.dataSyncStatus = "failed";
+					console.log("failed to load MAF records");
+					alert("there was an error downloading the address records for this area.  Please click the 'Clear Records from This Device' button, and re-download the records in this community");
+				}
+			}
+		);
+
+	};
+
+	MASSGIS.settings_updateUI = function () {
+		// fix this to reflect changes to OpenLayers.STATE of each feature in the layers
+		$('#settings_maf').html(MASSGIS.lyr_maf.features.length);
+		$('#settings_addrs').html(MASSGIS.lyr_address_points.features.length);
+	};
+
+	MASSGIS.renderLinkedAddresses = function () {
+		var addrs = [];
+		var addrPtIds = [];
+
+		addrs = MASSGIS.linkedAddressLayer.features;
+
+		$.each(addrs, function (idx, addr) {
+			addr['backgroundColor'] = (!addr['selStatus'] || addr['selStatus'] == 'pre_selected') ? '#eb0' : '#ee0';
+		});
+		html = $('#linkedAddressesTmpl').render(_.uniq(addrs.sort(MASSGIS.sort_maf_features_by_street)));
+		$('#linked_addrs ul').html(html);
+		$('#linked_addrs ul > li > span').controlgroup({ mini: true, shadow: true, type: "horizontal", corners: true });
+		$('#linked_addrs ul').listview('refresh');
+		$('#linked_addrs ul > li > span div div').button();
+	};
+
+	MASSGIS.mafDrawOffset = 1;
+	MASSGIS.mafDrawMultiple = 35;
+	MASSGIS.buildAddressAutocompletes = function () {
+		MASSGIS.streets_to_street_id_hash = {};
+		MASSGIS.sites_to_site_id_hash = {};
+		MASSGIS.sites_to_site_name_id_hash = {};
+
+		$.each(MASSGIS.lyr_maf.features, function (idx, feature) {
+			if (feature.attributes.street_name_id !== null && feature.attributes.street_name) {
+				if (!MASSGIS.streets_to_street_id_hash[feature.attributes.street_name]) {
+					MASSGIS.streets_to_street_id_hash[feature.attributes.street_name] = feature.attributes.street_name_id;
+				}
+			}
+
+			if (feature.attributes.site_name) {
+				if (!MASSGIS.sites_to_site_id_hash[feature.attributes.site_name]) {
+					MASSGIS.sites_to_site_id_hash[feature.attributes.site_name] = feature.attributes.site_id;
+				}
+				if (!MASSGIS.sites_to_site_name_id_hash[feature.attributes.site_name]) {
+					MASSGIS.sites_to_site_name_id_hash[feature.attributes.site_name] = feature.attributes.site_name_id;
+				}
 			}
 		});
+		MASSGIS.streets_list = Object.keys(MASSGIS.streets_to_street_id_hash);
+
+		// $.each(MASSGIS.lyr_maf.features, function(idx, feature) {
+		// 	if (feature.attributes.site_id !== null && feature.attributes.site_name) {
+		// 		if (!MASSGIS.sites_to_site_id_hash[feature.attributes.site_name]) {
+		// 			MASSGIS.sites_to_site_id_hash[feature.attributes.site_name] = feature.attributes.site_id;
+		// 		}
+		// 	}
+		// });
+		MASSGIS.sites_list = Object.keys(MASSGIS.sites_to_site_id_hash);
 	};
-	sendUpdates();
-};
 
-MASSGIS.sync_address_points_fail_count = 0;
-MASSGIS.sync_address_points = function() {
-	$('#linked_addrs_buttons #clear_button').trigger('click');
+	MASSGIS.renderAddressList = function () {
+		var featuresToList = /street|status/.test(MASSGIS.addressListMode)
+			? MASSGIS.lyr_maf.features.sort(MASSGIS.sort_maf_features_by_street)
+			: MASSGIS.lyr_maf_constrained.features;
+		var mafDrawAddrList = [];
 
-	//load all data from WFS on server, store into WebSQL vector database
-	return $.jsonp(
-		{
-			//url: "http://www.mapsonline.net/geoserver-2.1.1/wfs",
-			//url: 'https://wsgw.mass.gov/geoserver/wfs',
-		        //url: 'http://10.202.25.161:8080/geoserver/wfs',
-		        url: 'https://gis-prod.digital.mass.gov/geoserver/wfs',
-			//url: 'http://10.202.26.28/geoserver/wfs',
-			data: {
-				"request" : "getfeature",
-				//"typename" : "massgis:massgis_rockportma_address_pointm",
-				"typename": 'massgis:MAD.MAD_ADDRESS_POINTM',
-				//"outputformat" : "json",
-				"outputformat" : "text/javascript",
-				"service" : "WFS",
-				"version" : "1.0.0",
-				"cql_filter" : "community_id = '" + $('#msag_community').val() + "'",
-				"srsName" : "EPSG:900913"
-			},
-			callback: "_jqjsp_" + Math.round(Math.random() * 1000000),
-			beforeSend: function( settings) {
-				settings.data.callback = null;
-				settings.data.format_options="CALLBACK:" + settings.callback;
-			},
-			success: function(data, xhr, statusText) {
-				if (MASSGIS.dataSyncStatus == "failed") {
-					console.log("abandoning address point data-load response");
-					return;
-				}
-				if (data.features[0].id.indexOf("MAD.MAD_ADDRESS_POINTM") === -1) {
-					console.log("mis-routed jsonp response");
-					this.error();
-					return;
-				}
-				var reader = new OpenLayers.Format.GeoJSON();
-				var features = [];
-				$.each(data.features, function(idx, obj) {
-					var feature = reader.read(obj)[0];
-					feature.state = OpenLayers.State.INSERT;
-					delete feature.data;
-					features.push(feature);
-				});
-
-				MASSGIS.lyr_address_points.addFeatures(features);
-				MASSGIS.settings_updateUI();
-				MASSGIS.lyr_address_points.strategies[1].save();
-			},
-			"error": function() {
-				MASSGIS.dataSyncStatus = "failed";
-				console.log("failed to load address points");
-				alert("there was an error loading the address points for this area.  Please click the 'Clear Records from This Device' button, and re-download the records in this community");
-			}
-		}
-	);
-
-};
-
-MASSGIS.sync_maf = function() {
-
-	//load all data from WFS on server, store into WebSQL vector database
-	return $.jsonp(
-		{
-			//url: "http://www.mapsonline.net/geoserver-2.1.1/wfs",
-			//url: "https://wsgw.mass.gov/geoserver/wfs",
-			//url: "http://10.202.25.161:8080/geoserver/wfs",
-			url: "https://gis-prod.digital.mass.gov/geoserver/wfs",
-                        //url: "http://10.202.26.28/geoserver/wfs",
-			dataType: "jsonp",
-			data: {
-				"request" : "getfeature",
-				//"typename" : "massgis:massgis_rockportma_maf_d",
-				//"typename" : "massgis:MAD.MAD_MASTER_ADDRESS_STNAME_VIEW",
-				"typename" : "massgis:MAD.MADV_MASTER_ADDRESS_STNAME",
-				//"outputformat" : "json",
-				"outputformat" : "text/javascript",
-				"service" : "WFS",
-				"cql_filter" : "community_id = '" + $('#msag_community').val() + "'",
-				"version" : "1.0.0",
-				"srsName" : "EPSG:900913"
-			},
-			callback: "_jqjsp_" + Math.round(Math.random() * 1000000),
-			beforeSend: function(settings) {
-				settings.data.callback = null;
-				settings.data.format_options="CALLBACK:" + settings.callback;
-			},
-			"success" : function(data, xhr, statusText) {
-				if (MASSGIS.dataSyncStatus == "failed") {
-					console.log("abandoning maf data-load response");
-					return;
-				}
-				if (data.features[0].id.indexOf("MAD.MADV_MASTER_ADDRESS_STNAME") === -1) {
-					console.log("mis-routed jsonp response");
-					this.error();
-					return;
-				}
-				var reader = new OpenLayers.Format.GeoJSON();
-				var features = [];
-				$.each(data.features, function(idx, obj) {
-					var feature = reader.read(obj)[0];
-					feature.state = OpenLayers.State.INSERT;
-					delete feature.data;
-					features.push(feature);
-				});
-
-				MASSGIS.lyr_maf.addFeatures(features);
-				MASSGIS.settings_updateUI();
-				MASSGIS.lyr_maf.strategies[1].save();
-				MASSGIS.lyr_maf.features = MASSGIS.lyr_maf.features.sort(MASSGIS.sort_maf_features_by_street);
-			},
-			"error" : function() {
-				MASSGIS.dataSyncStatus = "failed";
-				console.log("failed to load MAF records");
-				alert("there was an error downloading the address records for this area.  Please click the 'Clear Records from This Device' button, and re-download the records in this community");
-			}
-		}
-	);
-
-};
-
-MASSGIS.settings_updateUI = function() {
-	// fix this to reflect changes to OpenLayers.STATE of each feature in the layers
-	$('#settings_maf').html(MASSGIS.lyr_maf.features.length);
-	$('#settings_addrs').html(MASSGIS.lyr_address_points.features.length);
-};
-
-MASSGIS.renderLinkedAddresses = function() {
-	var addrs = [];
-	var addrPtIds = [];
-
-	addrs = MASSGIS.linkedAddressLayer.features;
-
-	$.each(addrs, function(idx, addr) {
-		addr['backgroundColor'] = (!addr['selStatus'] || addr['selStatus'] == 'pre_selected') ? '#eb0' : '#ee0';
-	});
-	html = $('#linkedAddressesTmpl').render(_.uniq(addrs.sort(MASSGIS.sort_maf_features_by_street)));
-	$('#linked_addrs ul').html(html);
-	$('#linked_addrs ul > li > span').controlgroup({mini: true, shadow: true, type: "horizontal", corners: true});
-	$('#linked_addrs ul').listview('refresh');
-	$('#linked_addrs ul > li > span div div').button();
-};
-
-MASSGIS.mafDrawOffset = 1;
-MASSGIS.mafDrawMultiple = 35;
-MASSGIS.buildAddressAutocompletes = function() {
-	MASSGIS.streets_to_street_id_hash = {};
-	MASSGIS.sites_to_site_id_hash = {};
-	MASSGIS.sites_to_site_name_id_hash = {};
-
-	$.each(MASSGIS.lyr_maf.features, function(idx, feature) {
-		if (feature.attributes.street_name_id !== null && feature.attributes.street_name) {
-			if (!MASSGIS.streets_to_street_id_hash[feature.attributes.street_name]) {
-				MASSGIS.streets_to_street_id_hash[feature.attributes.street_name] = feature.attributes.street_name_id;
-			}
+		if (MASSGIS.addressListMode == 'status') {
+			featuresToList = _.filter(featuresToList, function (o) { return o.attributes.status_color == 'RED' });
 		}
 
-		if (feature.attributes.site_name) {
-			if (!MASSGIS.sites_to_site_id_hash[feature.attributes.site_name]) {
-				MASSGIS.sites_to_site_id_hash[feature.attributes.site_name] = feature.attributes.site_id;
-			}
-			if (!MASSGIS.sites_to_site_name_id_hash[feature.attributes.site_name]) {
-				MASSGIS.sites_to_site_name_id_hash[feature.attributes.site_name] = feature.attributes.site_name_id;
-			}
-		}
-	});
-	MASSGIS.streets_list = Object.keys(MASSGIS.streets_to_street_id_hash);
-
-	// $.each(MASSGIS.lyr_maf.features, function(idx, feature) {
-	// 	if (feature.attributes.site_id !== null && feature.attributes.site_name) {
-	// 		if (!MASSGIS.sites_to_site_id_hash[feature.attributes.site_name]) {
-	// 			MASSGIS.sites_to_site_id_hash[feature.attributes.site_name] = feature.attributes.site_id;
-	// 		}
-	// 	}
-	// });
-	MASSGIS.sites_list = Object.keys(MASSGIS.sites_to_site_id_hash);
-};
-
-MASSGIS.renderAddressList = function() {
-	var featuresToList = /street|status/.test(MASSGIS.addressListMode)
-		? MASSGIS.lyr_maf.features.sort(MASSGIS.sort_maf_features_by_street)
-		: MASSGIS.lyr_maf_constrained.features;
-	var mafDrawAddrList = [];
-
-	if (MASSGIS.addressListMode == 'status') {
-		featuresToList = _.filter(featuresToList,function(o){return o.attributes.status_color == 'RED'});
-	}
-
-	//MASSGIS.lyr_maf.features = MASSGIS.lyr_maf.features.sort(MASSGIS.sort_maf_features_by_street);
-	for (var i = Math.max(0,(MASSGIS.mafDrawOffset - 2)) * MASSGIS.mafDrawMultiple; i < Math.min(featuresToList.length, MASSGIS.mafDrawMultiple * MASSGIS.mafDrawOffset); i++) {
-		if (
+		//MASSGIS.lyr_maf.features = MASSGIS.lyr_maf.features.sort(MASSGIS.sort_maf_features_by_street);
+		for (var i = Math.max(0, (MASSGIS.mafDrawOffset - 2)) * MASSGIS.mafDrawMultiple; i < Math.min(featuresToList.length, MASSGIS.mafDrawMultiple * MASSGIS.mafDrawOffset); i++) {
+			if (
 				(featuresToList[i].attributes.address_status && featuresToList[i].attributes.address_status == 'DELETED') ||
 				(featuresToList[i].state && featuresToList[i].state == OpenLayers.State.DELETE)
-			)
-		{
-			continue;
+			) {
+				continue;
+			}
+			mafDrawAddrList.push(featuresToList[i]);
 		}
-		mafDrawAddrList.push(featuresToList[i]);
-	}
-	html = $('#addressListTmpl').render(mafDrawAddrList);
-	$('#addr_list ul').html(html);
-	$('#addr_list ul').listview('refresh');
+		html = $('#addressListTmpl').render(mafDrawAddrList);
+		$('#addr_list ul').html(html);
+		$('#addr_list ul').listview('refresh');
 
-	$('#street_name').trigger("change");
-};
+		$('#street_name').trigger("change");
+	};
 
-MASSGIS.loadAndCacheAGSLayer = function(opts) {
-	var ret = $.Deferred();
-	if (window.localStorage.getItem("ags_config_" + opts.url)) {
-		data = JSON.parse(window.localStorage.getItem("ags_config_" + opts.url));
-		opts.deferred = ret;
-		MASSGIS.loadAndCacheAGSLayerResponse(data,opts);
+	MASSGIS.loadAndCacheAGSLayer = function (opts) {
+		var ret = $.Deferred();
+		if (window.localStorage.getItem("ags_config_" + opts.url)) {
+			data = JSON.parse(window.localStorage.getItem("ags_config_" + opts.url));
+			opts.deferred = ret;
+			MASSGIS.loadAndCacheAGSLayerResponse(data, opts);
+			return ret;
+		}
+
+		$.jsonp(
+			{
+				url: opts.url,
+				data: {
+					f: "json"
+				},
+				callbackParameter: "callback",
+				callback: "fn_" + Math.round(10000 * Math.random(), 10)
+			}
+		).done(function (data) {
+			opts.deferred = ret;
+			MASSGIS.loadAndCacheAGSLayerResponse(data, opts);
+		});
+
 		return ret;
 	}
 
-	$.jsonp(
-		{
-			url: opts.url,
-			data: {
-				f: "json"
-			},
-			callbackParameter: "callback",
-			callback: "fn_" + Math.round(10000 * Math.random(),10)
+	MASSGIS.loadAndCacheAGSLayerResponse = function (data, opts) {
+		var layerInfo = data;
+		window.localStorage.setItem("ags_config_" + opts.url, JSON.stringify(layerInfo));
+		var layerMaxExtent = new OpenLayers.Bounds(
+			layerInfo.fullExtent.xmin,
+			layerInfo.fullExtent.ymin,
+			layerInfo.fullExtent.xmax,
+			layerInfo.fullExtent.ymax
+		);
+
+		var resolutions = [];
+		for (var i = 0; i < layerInfo.tileInfo.lods.length; i++) {
+			resolutions.push(layerInfo.tileInfo.lods[i].resolution);
 		}
-	).done(function(data) {
-		opts.deferred = ret;
-		MASSGIS.loadAndCacheAGSLayerResponse(data,opts);
-	});
 
-	return ret;
-}
-
-MASSGIS.loadAndCacheAGSLayerResponse = function(data,opts) {
-	var layerInfo = data;
-	window.localStorage.setItem("ags_config_" + opts.url,JSON.stringify(layerInfo));
-	var layerMaxExtent = new OpenLayers.Bounds(
-		layerInfo.fullExtent.xmin,
-		layerInfo.fullExtent.ymin,
-		layerInfo.fullExtent.xmax,
-		layerInfo.fullExtent.ymax
-	);
-
-	var resolutions = [];
-	for (var i=0; i<layerInfo.tileInfo.lods.length; i++) {
-		resolutions.push(layerInfo.tileInfo.lods[i].resolution);
-	}
-
-	// MASSGIS[opts.layerId] = new OpenLayers.Layer.ArcGISCache(opts.layerName, layerInfo.tileServers,
-	// {
-	// 	isBaseLayer: opts.isBaseLayer,
-	// 	resolutions: resolutions,
-	// 	tileSize: new OpenLayers.Size(layerInfo.tileInfo.cols, layerInfo.tileInfo.rows),
-	// 	tileOrigin: new OpenLayers.LonLat(layerInfo.tileInfo.origin.x , layerInfo.tileInfo.origin.y),
-	// 	maxExtent: layerMaxExtent,
-	// 	//projection: 'EPSG:' + layerInfo.spatialReference.wkid,
-	// 	projection: 'EPSG:900913',
-	// 	visibility: false,
-	// 	tileOptions: {
-	// 		crossOriginKeyword: "anonymous"
-	// 	},
-	// 	eventListeners: {
-	// 		tileloaded: function(evt) {
-	// 			if (evt && evt.tile.url.substr(0, 5) === "data:") {
-	// 				//console.log('cache hit on old orthos basemap');
-	// 			}
-	// 			else {
-	// 				//console.log('cache miss on old orthos basemap');
-	// 			}
-	// 		}
-	// 	}
-	// });
-	var customRes = MASSGIS.osmLayer.resolutions.slice(0).splice(0,20); // MassGIS layers are tiled through level 19, but osm only gives resolutions to level 18
-	opts.numZoomLevels && opts.numZoomLevels > 19 && customRes.push(0.2); // this gives the extra resolution level we need
-	MASSGIS[opts.layerId] = new OpenLayers.Layer.ArcGISCache( opts.layerName, [opts.url], {
-		isBaseLayer: opts.isBaseLayer,
-		resolutions: customRes,
-		numZoomLevels : opts.numZoomLevels || 19,
-		tileSize: new OpenLayers.Size(256, 256),
-		tileOrigin: new OpenLayers.LonLat(layerInfo.tileInfo.origin.x , layerInfo.tileInfo.origin.y),
-		projection: 'EPSG:900913',
-		tileOptions: {
-			crossOriginKeyword: "anonymous"
-		},
-		visibility: false
-		// eventListeners: {
-		// 	tileloaded: function(evt) {
-		// 		if (evt && evt.tile.url.substr(0, 5) === "data:") {
-		// 			//console.log('cache hit on old orthos basemap');
-		// 		}
-		// 		else {
-		// 			//console.log('cache miss on old orthos basemap');
+		// MASSGIS[opts.layerId] = new OpenLayers.Layer.ArcGISCache(opts.layerName, layerInfo.tileServers,
+		// {
+		// 	isBaseLayer: opts.isBaseLayer,
+		// 	resolutions: resolutions,
+		// 	tileSize: new OpenLayers.Size(layerInfo.tileInfo.cols, layerInfo.tileInfo.rows),
+		// 	tileOrigin: new OpenLayers.LonLat(layerInfo.tileInfo.origin.x , layerInfo.tileInfo.origin.y),
+		// 	maxExtent: layerMaxExtent,
+		// 	//projection: 'EPSG:' + layerInfo.spatialReference.wkid,
+		// 	projection: 'EPSG:900913',
+		// 	visibility: false,
+		// 	tileOptions: {
+		// 		crossOriginKeyword: "anonymous"
+		// 	},
+		// 	eventListeners: {
+		// 		tileloaded: function(evt) {
+		// 			if (evt && evt.tile.url.substr(0, 5) === "data:") {
+		// 				//console.log('cache hit on old orthos basemap');
+		// 			}
+		// 			else {
+		// 				//console.log('cache miss on old orthos basemap');
+		// 			}
 		// 		}
 		// 	}
-		// }
-	});
-	MASSGIS.map.addLayer(MASSGIS[opts.layerId]);
-	opts.deferred.resolve();
-}
-
-
-MASSGIS.init_map = function() {
-
-	MASSGIS.map = new OpenLayers.Map(
-		'map' ,
-		{
-			"controls": [
-				new OpenLayers.Control.TouchNavigation(),
-				new OpenLayers.Control.Navigation()
-			],
-			"projection" : "EPSG:900913"
-		}
-	);
-
-	MASSGIS.osmLayer = new OpenLayers.Layer.OSM("OpenStreetMap", null, {
-		numZoomLevels: 20,
-		eventListeners: {
-			tileloaded: function(evt) {
-				if (evt && evt.tile.url.substr(0, 5) === "data:") {
-					//console.log('cache hit on osm');
-				}
-				else {
-					//console.log('cache miss on osm');
-				}
-			}
-		}
-	});
-	MASSGIS.map.addLayer(MASSGIS.osmLayer);
-
-
-	//http://tiles.arcgis.com/tiles/hGdibHYSPO59RG1h/arcgis/rest/services/MassGISBasemap_Topo_Detailed_L3/MapServer
-	var topoLoaded = MASSGIS.loadAndCacheAGSLayer(
-		{
-			"layerId" : "topoBasemap",
-			"layerName" : "Topo Basemap",
-			"url" : "https://tiles.arcgis.com/tiles/hGdibHYSPO59RG1h/arcgis/rest/services/MassGISBasemap_Topo_Detailed_L3/MapServer",
-			"isBaseLayer" : true
-		});
-	topoLoaded.done(function() {
-		MASSGIS.map.removeLayer(MASSGIS.osmLayer);
-		MASSGIS.map.setBaseLayer(MASSGIS.topoBasemap);
-
-	});
-
-
-	var msagLoaded = MASSGIS.loadAndCacheAGSLayer(
-		{
-			"layerId" : "msagOverlay",
-			"layerName" : "MassGIS MSAG Overlay",
-			"url" : "https://tiles.arcgis.com/tiles/hGdibHYSPO59RG1h/arcgis/rest/services/MSAG_Communities/MapServer",
-			"isBaseLayer" : false
-		});
-	msagLoaded.done(function() {
-		MASSGIS.msagOverlay.setVisibility(false);
-		MASSGIS.map.events.on({
-			"changebaselayer": function() {
-				if (MASSGIS.map.baseLayer == MASSGIS.mgisOrthosStatewideLayer2014 || MASSGIS.map.baseLayer == MASSGIS.mgisOrthosStatewideLayer2015) {
-					if (MASSGIS.map.getZoom() <= 12) {
-						MASSGIS.msagOverlay.setVisibility(false);
-					} else {
-						MASSGIS.msagOverlay.setVisibility(true);
-					}
-					MASSGIS.map.baseLayer.setZIndex(6);
-					MASSGIS.msagOverlay.setZIndex(10);
-				} else {
-					MASSGIS.msagOverlay.setVisibility(false);
-				}
+		// });
+		var customRes = MASSGIS.osmLayer.resolutions.slice(0).splice(0, 20); // MassGIS layers are tiled through level 19, but osm only gives resolutions to level 18
+		opts.numZoomLevels && opts.numZoomLevels > 19 && customRes.push(0.2); // this gives the extra resolution level we need
+		MASSGIS[opts.layerId] = new OpenLayers.Layer.ArcGISCache(opts.layerName, [opts.url], {
+			isBaseLayer: opts.isBaseLayer,
+			resolutions: customRes,
+			numZoomLevels: opts.numZoomLevels || 19,
+			tileSize: new OpenLayers.Size(256, 256),
+			tileOrigin: new OpenLayers.LonLat(layerInfo.tileInfo.origin.x, layerInfo.tileInfo.origin.y),
+			projection: 'EPSG:900913',
+			tileOptions: {
+				crossOriginKeyword: "anonymous"
 			},
-			"zoomend" : function() {
-				if (MASSGIS.map.baseLayer == MASSGIS.mgisOrthosStatewideLayer2014 || MASSGIS.map.baseLayer == MASSGIS.mgisOrthosStatewideLayer2015) {
-					if (MASSGIS.map.getZoom() <= 12) {
-						MASSGIS.msagOverlay.setVisibility(false);
-					} else {
-						MASSGIS.map.baseLayer.setZIndex(6);
-						MASSGIS.msagOverlay.setVisibility(true);
-					}
-				}
+			visibility: false
+			// eventListeners: {
+			// 	tileloaded: function(evt) {
+			// 		if (evt && evt.tile.url.substr(0, 5) === "data:") {
+			// 			//console.log('cache hit on old orthos basemap');
+			// 		}
+			// 		else {
+			// 			//console.log('cache miss on old orthos basemap');
+			// 		}
+			// 	}
+			// }
+		});
+		MASSGIS.map.addLayer(MASSGIS[opts.layerId]);
+		opts.deferred.resolve();
+	}
+
+
+	MASSGIS.init_map = function () {
+
+		MASSGIS.map = new OpenLayers.Map(
+			'map',
+			{
+				"controls": [
+					new OpenLayers.Control.TouchNavigation(),
+					new OpenLayers.Control.Navigation()
+				],
+				"projection": "EPSG:900913"
 			}
-		});
-	});
+		);
 
-	var streetsLoaded = MASSGIS.loadAndCacheAGSLayer(
-		{
-			"layerId" : "streetsOverlay",
-			"layerName" : "MassGIS Streets Overlay",
-			//"url" : "http://gisprpxy.itd.state.ma.us/arcgisserver/rest/services/Basemaps/Base_Streets_with_Labels/MapServer",
-			//"url" : "https://tiles.arcgis.com/tiles/hGdibHYSPO59RG1h/arcgis/rest/services/StreetsBasemap2/MapServer",
-			"url" : "https://tiles.arcgis.com/tiles/hGdibHYSPO59RG1h/arcgis/rest/services/Base_Streets_with_Labels/MapServer",
-			"isBaseLayer" : false,
-			"numZoomLevels" : 20
-		});
-	streetsLoaded.done(function() {
-		MASSGIS.streetsOverlay.setVisibility(false);
-		MASSGIS.map.events.on({
-			"changebaselayer": function() {
-				if (MASSGIS.map.baseLayer == MASSGIS.mgisOrthosStatewideLayer2014 || MASSGIS.map.baseLayer == MASSGIS.mgisOrthosStatewideLayer2015) {
-					if (MASSGIS.map.getZoom() <= 12) {
-						MASSGIS.streetsOverlay.setVisibility(false);
-					} else {
-						MASSGIS.streetsOverlay.setVisibility(true);
-					}
-					MASSGIS.streetsOverlay.setZIndex(10);
-				} else {
-					MASSGIS.streetsOverlay.setVisibility(false);
-				}
-			},
-			"zoomend" : function() {
-				if (MASSGIS.map.baseLayer == MASSGIS.mgisOrthosStatewideLayer2014 || MASSGIS.map.baseLayer == MASSGIS.mgisOrthosStatewideLayer2015) {
-					if (MASSGIS.map.getZoom() <= 12) {
-						MASSGIS.streetsOverlay.setVisibility(false);
-					} else {
-						MASSGIS.streetsOverlay.setVisibility(true);
-					}
-				}
-			}
-		});
-	});
-
-	var statewideOrthosLoaded2014 = MASSGIS.loadAndCacheAGSLayer(
-		{
-			"layerId" : "mgisOrthosStatewideLayer2014",
-			"layerName" : "MassGIS Statewide BaseMap",
-			//"url" : "http://gisprpxy.itd.state.ma.us/arcgisserver/rest/services/Basemaps/Orthos_DigitalGlobe2011_2012/MapServer",
-			//"url" : "https://tiles.arcgis.com/tiles/hGdibHYSPO59RG1h/arcgis/rest/services/DigitalGlobe_2011_2012/MapServer",
-			"url" : "https://tiles.arcgis.com/tiles/hGdibHYSPO59RG1h/arcgis/rest/services/USGS_Orthos_2013_2014/MapServer",
-			"isBaseLayer" : true
-		});
-	statewideOrthosLoaded2014.done(function() {
-		MASSGIS.mgisOrthosStatewideLayer2014.setZIndex(6);
-	});
-	var wmts = {
-		"Google 2014-2015 Orthoimagery": {
-			"layer": "imagery",
-			"matrix_ids": [
-				"0to20:00",
-				"0to20:01",
-				"0to20:02",
-				"0to20:03",
-				"0to20:04",
-				"0to20:05",
-				"0to20:06",
-				"0to20:07",
-				"0to20:08",
-				"0to20:09",
-				"0to20:10",
-				"0to20:11",
-				"0to20:12",
-				"0to20:13",
-				"0to20:14",
-				"0to20:15",
-				"0to20:16",
-				"0to20:17",
-				"0to20:18",
-				"0to20:19",
-				"0to20:20"
-			],
-			"matrix_set": "0to20",
-			"title": "Google_2014_2015_WMTS",
-			"url": "https://orthos.massgis.state.ma.us/login/path/major-madam-cricket-caviar/wmts?"
-		}
-	};
-	MASSGIS.mgisOrthosStatewideLayer2015 = new OpenLayers.Layer.WMTS({
-		name:        'Google 2014-2015 Orthoimagery'
-		,url:         wmts['Google 2014-2015 Orthoimagery'].url
-		,layer:       wmts['Google 2014-2015 Orthoimagery'].layer
-		,matrixSet:   wmts['Google 2014-2015 Orthoimagery'].matrix_set
-		,matrixIds:   wmts['Google 2014-2015 Orthoimagery'].matrix_ids
-		,format:      'image/png'
-		,style:       '_null'
-		,attribution: ''
-		,projection:  'EPSG:900913'
-		,numZoomLevels: wmts['Google 2014-2015 Orthoimagery'].matrix_ids.length
-	});
-	MASSGIS.map.addLayer(MASSGIS.mgisOrthosStatewideLayer2015);
-	MASSGIS.mgisOrthosStatewideLayer2015.setZIndex(6);
-
-	MASSGIS.blankBaseLayer = new OpenLayers.Layer.WMS("Blank",
-		'img/white.png',
-		{},
-		{
-			isBaseLayer : true,
-			maxScale : 100,
-			minScale : 5000000,
-			projection : "EPSG:900913",
-			units : 'm'
-		}
-	);
-	MASSGIS.map.addLayer(MASSGIS.blankBaseLayer);
-
-	$.when(msagLoaded,streetsLoaded).then(function() {
-		MASSGIS.tilesDB = openDatabase('offline_tiles', '1.0', 'MassGIS Offline Tile Storage', 20 * 1024 * 1024);
-		MASSGIS.tilesDB.transaction(function(tx) {
-			tx.executeSql('CREATE TABLE IF NOT EXISTS tiles (url text unique, datauri text)');
-		});
-		var cacheRead = new OpenLayers.Control.CacheRead({
-			autoActivate : true,
-			layers : [MASSGIS.osmLayer,MASSGIS.mgisOrthosStatewideLayer2014,MASSGIS.mgisOrthosStatewideLayer2015,MASSGIS.streetsOverlay]
-			,fetch: function(evt) {
-				if (this.active && window.localStorage && evt.tile instanceof OpenLayers.Tile.Image) {
-					var tile = evt.tile,
-					url = tile.url;
-					// deal with modified tile urls when both CacheWrite and CacheRead
-					// are active
-					if (!tile.layer.crossOriginKeyword && OpenLayers.ProxyHost && url.indexOf(OpenLayers.ProxyHost) === 0) {
-						url = OpenLayers.Control.CacheWrite.urlMap[url];
-					}
-					var dataURI = window.localStorage.getItem("olCache_" + url);
-					MASSGIS.tilesDB.transaction(function (tx) {
-						tx.executeSql('SELECT * FROM tiles where url = ?', ["olCache_" + url], function (tx, results) {
-							if (results.rows.length > 0) {
-								//console.log("cache hit for tile " + url);
-								tile.url = results.rows.item(0).url;
-								if (evt.type === "tileerror") {
-									//tile.setImgSrc(results.rows.item(0).datauri);
-								}
-							} else {
-								//console.log("cache miss for tile " + url);
-							}
-						});
-					});
-//					if (dataURI) {
-//						console.log("cache hit for tile " + url);
-//						tile.url = dataURI;
-//						if (evt.type === "tileerror") {
-//							tile.setImgSrc(dataURI);
-//						}
-//					} else {
-//						//console.log("cache miss for tile " + url);
-//					}
-				}
-			}
-		});
-		//MASSGIS.map.addControl(cacheRead);
-
-		MASSGIS.cacheWrite = new OpenLayers.Control.CacheWrite({
-			autoActivate: true,
-			imageFormat: "image/png",
+		MASSGIS.osmLayer = new OpenLayers.Layer.OSM("OpenStreetMap", null, {
+			numZoomLevels: 20,
 			eventListeners: {
-				cachefull: function() {
-					console.log("Cache full!");
+				tileloaded: function (evt) {
+					if (evt && evt.tile.url.substr(0, 5) === "data:") {
+						//console.log('cache hit on osm');
+					}
+					else {
+						//console.log('cache miss on osm');
+					}
 				}
-			},
-			cache: function(obj) {
-				if (this.active && window.localStorage) {
-					var tile = obj.tile;
-					if (tile instanceof OpenLayers.Tile.Image &&
-						tile.url.substr(0, 5) !== 'data:') {
-						try {
-							var canvasContext = tile.getCanvasContext();
-							if (canvasContext) {
-								var urlMap = OpenLayers.Control.CacheWrite.urlMap;
-								var url = urlMap[tile.url] || tile.url;
-/*
-								window.localStorage.setItem(
-									"olCache_" + url,
-									canvasContext.canvas.toDataURL(this.imageFormat)
-								);
-*/
-								MASSGIS.tilesDB.transaction(function (tx) {
-									tx.executeSql('INSERT INTO tiles (url, datauri) VALUES (?,?)', ["olCache_" + url, canvasContext.canvas.toDataURL(this.imageFormat)]);
-								});
-								delete urlMap[tile.url];
-//console.log("cached tile " + tile.url);
-							}
-						} catch(e) {
-							// local storage full or CORS violation
-							var reason = e.name || e.message;
-							if (reason && this.quotaRegEx.test(reason)) {
-								this.events.triggerEvent("cachefull", {tile: tile});
-							} else {
-								OpenLayers.Console.error(e.toString());
+			}
+		});
+		MASSGIS.map.addLayer(MASSGIS.osmLayer);
+
+
+		//http://tiles.arcgis.com/tiles/hGdibHYSPO59RG1h/arcgis/rest/services/MassGISBasemap_Topo_Detailed_L3/MapServer
+		var topoLoaded = MASSGIS.loadAndCacheAGSLayer(
+			{
+				"layerId": "topoBasemap",
+				"layerName": "Topo Basemap",
+				"url": "https://tiles.arcgis.com/tiles/hGdibHYSPO59RG1h/arcgis/rest/services/MassGISBasemap_Topo_Detailed_L3/MapServer",
+				"isBaseLayer": true
+			});
+		topoLoaded.done(function () {
+			MASSGIS.map.removeLayer(MASSGIS.osmLayer);
+			MASSGIS.map.setBaseLayer(MASSGIS.topoBasemap);
+
+		});
+
+
+		var msagLoaded = MASSGIS.loadAndCacheAGSLayer(
+			{
+				"layerId": "msagOverlay",
+				"layerName": "MassGIS MSAG Overlay",
+				"url": "https://tiles.arcgis.com/tiles/hGdibHYSPO59RG1h/arcgis/rest/services/MSAG_Communities/MapServer",
+				"isBaseLayer": false
+			});
+		msagLoaded.done(function () {
+			MASSGIS.msagOverlay.setVisibility(false);
+			MASSGIS.map.events.on({
+				"changebaselayer": function () {
+					if (MASSGIS.map.baseLayer == MASSGIS.mgisOrthosStatewideLayer2014 || MASSGIS.map.baseLayer == MASSGIS.mgisOrthosStatewideLayer2015) {
+						if (MASSGIS.map.getZoom() <= 12) {
+							MASSGIS.msagOverlay.setVisibility(false);
+						} else {
+							MASSGIS.msagOverlay.setVisibility(true);
+						}
+						MASSGIS.map.baseLayer.setZIndex(6);
+						MASSGIS.msagOverlay.setZIndex(10);
+					} else {
+						MASSGIS.msagOverlay.setVisibility(false);
+					}
+				},
+				"zoomend": function () {
+					if (MASSGIS.map.baseLayer == MASSGIS.mgisOrthosStatewideLayer2014 || MASSGIS.map.baseLayer == MASSGIS.mgisOrthosStatewideLayer2015) {
+						if (MASSGIS.map.getZoom() <= 12) {
+							MASSGIS.msagOverlay.setVisibility(false);
+						} else {
+							MASSGIS.map.baseLayer.setZIndex(6);
+							MASSGIS.msagOverlay.setVisibility(true);
+						}
+					}
+				}
+			});
+		});
+
+		var streetsLoaded = MASSGIS.loadAndCacheAGSLayer(
+			{
+				"layerId": "streetsOverlay",
+				"layerName": "MassGIS Streets Overlay",
+				//"url" : "http://gisprpxy.itd.state.ma.us/arcgisserver/rest/services/Basemaps/Base_Streets_with_Labels/MapServer",
+				//"url" : "https://tiles.arcgis.com/tiles/hGdibHYSPO59RG1h/arcgis/rest/services/StreetsBasemap2/MapServer",
+				"url": "https://tiles.arcgis.com/tiles/hGdibHYSPO59RG1h/arcgis/rest/services/Base_Streets_with_Labels/MapServer",
+				"isBaseLayer": false,
+				"numZoomLevels": 20
+			});
+		streetsLoaded.done(function () {
+			MASSGIS.streetsOverlay.setVisibility(false);
+			MASSGIS.map.events.on({
+				"changebaselayer": function () {
+					if (MASSGIS.map.baseLayer == MASSGIS.mgisOrthosStatewideLayer2014 || MASSGIS.map.baseLayer == MASSGIS.mgisOrthosStatewideLayer2015) {
+						if (MASSGIS.map.getZoom() <= 12) {
+							MASSGIS.streetsOverlay.setVisibility(false);
+						} else {
+							MASSGIS.streetsOverlay.setVisibility(true);
+						}
+						MASSGIS.streetsOverlay.setZIndex(10);
+					} else {
+						MASSGIS.streetsOverlay.setVisibility(false);
+					}
+				},
+				"zoomend": function () {
+					if (MASSGIS.map.baseLayer == MASSGIS.mgisOrthosStatewideLayer2014 || MASSGIS.map.baseLayer == MASSGIS.mgisOrthosStatewideLayer2015) {
+						if (MASSGIS.map.getZoom() <= 12) {
+							MASSGIS.streetsOverlay.setVisibility(false);
+						} else {
+							MASSGIS.streetsOverlay.setVisibility(true);
+						}
+					}
+				}
+			});
+		});
+
+		var statewideOrthosLoaded2014 = MASSGIS.loadAndCacheAGSLayer(
+			{
+				"layerId": "mgisOrthosStatewideLayer2014",
+				"layerName": "MassGIS Statewide BaseMap",
+				//"url" : "http://gisprpxy.itd.state.ma.us/arcgisserver/rest/services/Basemaps/Orthos_DigitalGlobe2011_2012/MapServer",
+				//"url" : "https://tiles.arcgis.com/tiles/hGdibHYSPO59RG1h/arcgis/rest/services/DigitalGlobe_2011_2012/MapServer",
+				"url": "https://tiles.arcgis.com/tiles/hGdibHYSPO59RG1h/arcgis/rest/services/USGS_Orthos_2013_2014/MapServer",
+				"isBaseLayer": true
+			});
+		statewideOrthosLoaded2014.done(function () {
+			MASSGIS.mgisOrthosStatewideLayer2014.setZIndex(6);
+		});
+		var wmts = {
+			"Google 2014-2015 Orthoimagery": {
+				"layer": "imagery",
+				"matrix_ids": [
+					"0to20:00",
+					"0to20:01",
+					"0to20:02",
+					"0to20:03",
+					"0to20:04",
+					"0to20:05",
+					"0to20:06",
+					"0to20:07",
+					"0to20:08",
+					"0to20:09",
+					"0to20:10",
+					"0to20:11",
+					"0to20:12",
+					"0to20:13",
+					"0to20:14",
+					"0to20:15",
+					"0to20:16",
+					"0to20:17",
+					"0to20:18",
+					"0to20:19",
+					"0to20:20"
+				],
+				"matrix_set": "0to20",
+				"title": "Google_2014_2015_WMTS",
+				"url": "https://orthos.massgis.state.ma.us/login/path/major-madam-cricket-caviar/wmts?"
+			}
+		};
+		MASSGIS.mgisOrthosStatewideLayer2015 = new OpenLayers.Layer.WMTS({
+			name: 'Google 2014-2015 Orthoimagery'
+			, url: wmts['Google 2014-2015 Orthoimagery'].url
+			, layer: wmts['Google 2014-2015 Orthoimagery'].layer
+			, matrixSet: wmts['Google 2014-2015 Orthoimagery'].matrix_set
+			, matrixIds: wmts['Google 2014-2015 Orthoimagery'].matrix_ids
+			, format: 'image/png'
+			, style: '_null'
+			, attribution: ''
+			, projection: 'EPSG:900913'
+			, numZoomLevels: wmts['Google 2014-2015 Orthoimagery'].matrix_ids.length
+		});
+		MASSGIS.map.addLayer(MASSGIS.mgisOrthosStatewideLayer2015);
+		MASSGIS.mgisOrthosStatewideLayer2015.setZIndex(6);
+
+		MASSGIS.blankBaseLayer = new OpenLayers.Layer.WMS("Blank",
+			'img/white.png',
+			{},
+			{
+				isBaseLayer: true,
+				maxScale: 100,
+				minScale: 5000000,
+				projection: "EPSG:900913",
+				units: 'm'
+			}
+		);
+		MASSGIS.map.addLayer(MASSGIS.blankBaseLayer);
+
+		$.when(msagLoaded, streetsLoaded).then(function () {
+			MASSGIS.tilesDB = openDatabase('offline_tiles', '1.0', 'MassGIS Offline Tile Storage', 20 * 1024 * 1024);
+			MASSGIS.tilesDB.transaction(function (tx) {
+				tx.executeSql('CREATE TABLE IF NOT EXISTS tiles (url text unique, datauri text)');
+			});
+			var cacheRead = new OpenLayers.Control.CacheRead({
+				autoActivate: true,
+				layers: [MASSGIS.osmLayer, MASSGIS.mgisOrthosStatewideLayer2014, MASSGIS.mgisOrthosStatewideLayer2015, MASSGIS.streetsOverlay]
+				, fetch: function (evt) {
+					if (this.active && window.localStorage && evt.tile instanceof OpenLayers.Tile.Image) {
+						var tile = evt.tile,
+							url = tile.url;
+						// deal with modified tile urls when both CacheWrite and CacheRead
+						// are active
+						if (!tile.layer.crossOriginKeyword && OpenLayers.ProxyHost && url.indexOf(OpenLayers.ProxyHost) === 0) {
+							url = OpenLayers.Control.CacheWrite.urlMap[url];
+						}
+						var dataURI = window.localStorage.getItem("olCache_" + url);
+						MASSGIS.tilesDB.transaction(function (tx) {
+							tx.executeSql('SELECT * FROM tiles where url = ?', ["olCache_" + url], function (tx, results) {
+								if (results.rows.length > 0) {
+									//console.log("cache hit for tile " + url);
+									tile.url = results.rows.item(0).url;
+									if (evt.type === "tileerror") {
+										//tile.setImgSrc(results.rows.item(0).datauri);
+									}
+								} else {
+									//console.log("cache miss for tile " + url);
+								}
+							});
+						});
+						//					if (dataURI) {
+						//						console.log("cache hit for tile " + url);
+						//						tile.url = dataURI;
+						//						if (evt.type === "tileerror") {
+						//							tile.setImgSrc(dataURI);
+						//						}
+						//					} else {
+						//						//console.log("cache miss for tile " + url);
+						//					}
+					}
+				}
+			});
+			//MASSGIS.map.addControl(cacheRead);
+
+			MASSGIS.cacheWrite = new OpenLayers.Control.CacheWrite({
+				autoActivate: true,
+				imageFormat: "image/png",
+				eventListeners: {
+					cachefull: function () {
+						console.log("Cache full!");
+					}
+				},
+				cache: function (obj) {
+					if (this.active && window.localStorage) {
+						var tile = obj.tile;
+						if (tile instanceof OpenLayers.Tile.Image &&
+							tile.url.substr(0, 5) !== 'data:') {
+							try {
+								var canvasContext = tile.getCanvasContext();
+								if (canvasContext) {
+									var urlMap = OpenLayers.Control.CacheWrite.urlMap;
+									var url = urlMap[tile.url] || tile.url;
+									/*
+																	window.localStorage.setItem(
+																		"olCache_" + url,
+																		canvasContext.canvas.toDataURL(this.imageFormat)
+																	);
+									*/
+									MASSGIS.tilesDB.transaction(function (tx) {
+										tx.executeSql('INSERT INTO tiles (url, datauri) VALUES (?,?)', ["olCache_" + url, canvasContext.canvas.toDataURL(this.imageFormat)]);
+									});
+									delete urlMap[tile.url];
+									//console.log("cached tile " + tile.url);
+								}
+							} catch (e) {
+								// local storage full or CORS violation
+								var reason = e.name || e.message;
+								if (reason && this.quotaRegEx.test(reason)) {
+									this.events.triggerEvent("cachefull", { tile: tile });
+								} else {
+									OpenLayers.Console.error(e.toString());
+								}
 							}
 						}
 					}
 				}
-			}
+			});
+			//MASSGIS.map.addControl(MASSGIS.cacheWrite);
 		});
-		//MASSGIS.map.addControl(MASSGIS.cacheWrite);
-	});
 
-	// Could be implemented much cheaper as a straight-up object/list
-	MASSGIS.linkedAddressLayer = new OpenLayers.Layer.Vector("Linked Address Layer", {
-		projection: "EPSG:900913",
-		style: {
-		},
-		eventListeners: {
-			featuresremoved: function(obj) {
-				MASSGIS.renderLinkedAddresses();
+		// Could be implemented much cheaper as a straight-up object/list
+		MASSGIS.linkedAddressLayer = new OpenLayers.Layer.Vector("Linked Address Layer", {
+			projection: "EPSG:900913",
+			style: {
 			},
-			featuresadded: function(obj) {
-				MASSGIS.renderLinkedAddresses();
-			}
-		},
-		renderers: ['Canvas']
-	});
-	MASSGIS.map.addLayer(MASSGIS.linkedAddressLayer);
+			eventListeners: {
+				featuresremoved: function (obj) {
+					MASSGIS.renderLinkedAddresses();
+				},
+				featuresadded: function (obj) {
+					MASSGIS.renderLinkedAddresses();
+				}
+			},
+			renderers: ['Canvas']
+		});
+		MASSGIS.map.addLayer(MASSGIS.linkedAddressLayer);
 
-	MASSGIS.preSelectionLayer = new OpenLayers.Layer.SpatialIndexedVector("Pre-Selection Layer", {
-		projection: "EPSG:900913",
-		style: {
-			"pointRadius": 25,
-			"fillColor": '#da0',
-			"fillOpacity": .8
-		},
-		eventListeners: {
-			featuresremoved: function(obj) {
-				//MASSGIS.renderLinkedAddresses();
+		MASSGIS.preSelectionLayer = new OpenLayers.Layer.SpatialIndexedVector("Pre-Selection Layer", {
+			projection: "EPSG:900913",
+			style: {
+				"pointRadius": 25,
+				"fillColor": '#da0',
+				"fillOpacity": .8
 			},
-			featuresadded: function(obj) {
-				//MASSGIS.checkMarkPrimary();
-				$.each(obj.features, function(idx, feature) {
-					if (MASSGIS.linkedAddressLayer.getFeaturesByAttribute("address_point_id",feature.attributes.address_point_id).length > 0) {
-						return;
-					} else {
-						var features = MASSGIS.lyr_maf.getFeaturesByAttribute("address_point_id",feature.attributes.address_point_id);
-						$.each(features, function(idx, feature) {
-							feature.selStatus = 'pre_selected';
-						});
-						MASSGIS.linkedAddressLayer.addFeatures(features);
+			eventListeners: {
+				featuresremoved: function (obj) {
+					//MASSGIS.renderLinkedAddresses();
+				},
+				featuresadded: function (obj) {
+					//MASSGIS.checkMarkPrimary();
+					$.each(obj.features, function (idx, feature) {
+						if (MASSGIS.linkedAddressLayer.getFeaturesByAttribute("address_point_id", feature.attributes.address_point_id).length > 0) {
+							return;
+						} else {
+							var features = MASSGIS.lyr_maf.getFeaturesByAttribute("address_point_id", feature.attributes.address_point_id);
+							$.each(features, function (idx, feature) {
+								feature.selStatus = 'pre_selected';
+							});
+							MASSGIS.linkedAddressLayer.addFeatures(features);
+						}
+					});
+					MASSGIS.renderLinkedAddresses();
+				}
+			},
+			renderers: ['Canvas']
+		});
+		MASSGIS.map.addLayer(MASSGIS.preSelectionLayer);
+
+		MASSGIS.checkMarkPrimary = function () {
+			if (MASSGIS.preSelectionLayer.features.length == 1 && MASSGIS.selectionLayer.features.length == 1 && (MASSGIS.lyr_address_points.getFeaturesByAttribute("address_point_id", MASSGIS.selectionLayer.features[0].attributes.address_point_id)[0]).geometry.components.length > 1) {
+				var isMarkPrimary = true;
+				$.each(MASSGIS.linkedAddressLayer.features, function (idx, laRec) {
+					if (laRec.selStatus == 'selected') {
+						isMarkPrimary = false;
+						return false;
 					}
 				});
-				MASSGIS.renderLinkedAddresses();
+				isMarkPrimary && $('#linked_addrs_buttons #link_button span span').text('Mark Primary');
+				!isMarkPrimary && $('#linked_addrs_buttons #link_button span span').text('Link');
 			}
-		},
-		renderers: ['Canvas']
-	});
-	MASSGIS.map.addLayer(MASSGIS.preSelectionLayer);
-
-	MASSGIS.checkMarkPrimary = function() {
-		if (MASSGIS.preSelectionLayer.features.length == 1 && MASSGIS.selectionLayer.features.length == 1 && (MASSGIS.lyr_address_points.getFeaturesByAttribute("address_point_id",MASSGIS.selectionLayer.features[0].attributes.address_point_id)[0]).geometry.components.length > 1) {
-			var isMarkPrimary = true;
-			$.each(MASSGIS.linkedAddressLayer.features, function(idx, laRec) {
-				if (laRec.selStatus == 'selected') {
-					isMarkPrimary = false;
-					return false;
-				}
-			});
-			isMarkPrimary && $('#linked_addrs_buttons #link_button span span').text('Mark Primary');
-			!isMarkPrimary && $('#linked_addrs_buttons #link_button span span').text('Link');
-		}
-		else {
-			$('#linked_addrs_buttons #link_button span span').text('Link');
-		}
-	};
-	MASSGIS.selectionLayer = new OpenLayers.Layer.SpatialIndexedVector("Selection Layer", {
-		projection: "EPSG:900913",
-		style: {
-			"pointRadius": 25,
-			"fillColor": '#ee0',
-			"fillOpacity": .8
-		},
-		eventListeners: {
-			featuresremoved: function(obj) {
-				//MASSGIS.checkMarkPrimary();
-				MASSGIS.renderLinkedAddresses();
+			else {
+				$('#linked_addrs_buttons #link_button span span').text('Link');
+			}
+		};
+		MASSGIS.selectionLayer = new OpenLayers.Layer.SpatialIndexedVector("Selection Layer", {
+			projection: "EPSG:900913",
+			style: {
+				"pointRadius": 25,
+				"fillColor": '#ee0',
+				"fillOpacity": .8
 			},
-			featuresadded: function(obj) {
-				//MASSGIS.checkMarkPrimary();
-				MASSGIS.renderLinkedAddresses();
+			eventListeners: {
+				featuresremoved: function (obj) {
+					//MASSGIS.checkMarkPrimary();
+					MASSGIS.renderLinkedAddresses();
+				},
+				featuresadded: function (obj) {
+					//MASSGIS.checkMarkPrimary();
+					MASSGIS.renderLinkedAddresses();
+				}
+			},
+			renderers: ['Canvas']
+		});
+		MASSGIS.map.addLayer(MASSGIS.selectionLayer);
+
+		MASSGIS.map.setCenter(
+			new OpenLayers.LonLat(-71.9110107421875, 42.44778143462245).transform(
+				new OpenLayers.Projection("EPSG:4326"),
+				MASSGIS.map.getProjectionObject()
+			), 9
+		);
+
+		var click = new OpenLayers.Control.Clickhold();
+		click.events.register("click", {}, function (e) {
+
+			var clickedPt = MASSGIS.map.getLonLatFromPixel(e.evt.xy);
+			var buffer = MASSGIS.map.getResolution() * MASSGIS.config.tapTolerance;
+			var searchRect = { x: clickedPt.lon - buffer, y: clickedPt.lat - buffer, w: buffer * 2, h: buffer * 2 }
+			var html = '';
+
+			var selAddrs = [];
+			var potentialSelAddrs = [];
+			var targetPoint = false;
+			if (MASSGIS.map.getResolution() < MASSGIS.lyr_address_points.maxResolution) {
+				potentialSelAddrs = MASSGIS.lyr_address_points.spatialIndex.search(searchRect);
+			} else {
+				//console.log("completed addresses out of scale");
 			}
-		},
-		renderers: ['Canvas']
-	});
-	MASSGIS.map.addLayer(MASSGIS.selectionLayer);
 
-	MASSGIS.map.setCenter(
-		new OpenLayers.LonLat( -71.9110107421875, 42.44778143462245).transform(
-			new OpenLayers.Projection("EPSG:4326"),
-			MASSGIS.map.getProjectionObject()
-		), 9
-	);
-
-	var click = new OpenLayers.Control.Clickhold();
-	click.events.register("click", {}, function(e) {
-
-		var clickedPt = MASSGIS.map.getLonLatFromPixel(e.evt.xy);
-		var buffer = MASSGIS.map.getResolution() * MASSGIS.config.tapTolerance;
-		var searchRect = {x:clickedPt.lon - buffer, y:clickedPt.lat - buffer, w: buffer * 2, h: buffer * 2}
-		var html = '';
-
-		var selAddrs = [];
-		var potentialSelAddrs = [];
-		var targetPoint = false;
-		if (MASSGIS.map.getResolution() < MASSGIS.lyr_address_points.maxResolution) {
-			potentialSelAddrs = MASSGIS.lyr_address_points.spatialIndex.search(searchRect);
-		} else {
-			//console.log("completed addresses out of scale");
-		}
-
-		if (potentialSelAddrs.length !== 0) {
-			$.each(potentialSelAddrs, function(idx, mpt) {
-				if (mpt.attributes && mpt.attributes.geographic_edit_status == "DELETED") {
-					return;
-				}
-				if (mpt.attributes && mpt.attributes.point_type == 'GC') {
-					return;
-				}
-				if (mpt.attributes && mpt.attributes.type_icon == 'NONE' && mpt.attributes.status_color == 'NONE') {
-					return;
-				}
-				if (mpt.geometry.components.length > 1) {
-					$.each(mpt.geometry.components, function(idx, pt) {
-						if (pt && pt.distanceTo(new OpenLayers.Geometry.Point(clickedPt.lon,clickedPt.lat)) < buffer) {
+			if (potentialSelAddrs.length !== 0) {
+				$.each(potentialSelAddrs, function (idx, mpt) {
+					if (mpt.attributes && mpt.attributes.geographic_edit_status == "DELETED") {
+						return;
+					}
+					if (mpt.attributes && mpt.attributes.point_type == 'GC') {
+						return;
+					}
+					if (mpt.attributes && mpt.attributes.type_icon == 'NONE' && mpt.attributes.status_color == 'NONE') {
+						return;
+					}
+					if (mpt.geometry.components.length > 1) {
+						$.each(mpt.geometry.components, function (idx, pt) {
+							if (pt && pt.distanceTo(new OpenLayers.Geometry.Point(clickedPt.lon, clickedPt.lat)) < buffer) {
+								selAddrs.push(mpt);
+								return false;
+							}
+						});
+					} else {
+						if (mpt.geometry.components[0] && mpt.geometry.components[0].distanceTo(new OpenLayers.Geometry.Point(clickedPt.lon, clickedPt.lat)) < buffer) {
 							selAddrs.push(mpt);
 							return false;
 						}
-					});
-				} else {
-					if (mpt.geometry.components[0] && mpt.geometry.components[0].distanceTo(new OpenLayers.Geometry.Point(clickedPt.lon,clickedPt.lat)) < buffer) {
-						selAddrs.push(mpt);
-						return false;
 					}
-				}
-			});
-		}
-
-		MASSGIS.pointsSelected(selAddrs, clickedPt, buffer);
-		fixgeometry();
-	});
-	MASSGIS.wktReader = new OpenLayers.Format.WKT();
-	click.events.register("clickhold", {}, function(e) {
-		// no long-tap actions if we're over the max resolution of the address points layer
-		if (MASSGIS.map.getResolution() > MASSGIS.lyr_address_points.maxResolution) {
-			return;
-		}
-
-		// find all the points we long-tapped on
-		var clickedPt = MASSGIS.map.getLonLatFromPixel(e.evt.xy);
-		var buffer = MASSGIS.map.getResolution() * MASSGIS.config.tapTolerance;
-		var searchRect = {x:clickedPt.lon - buffer, y:clickedPt.lat - buffer, w: buffer * 2, h: buffer * 2}
-
-		var potentialPts = [];
-		potentialPts = potentialPts.concat(MASSGIS.lyr_address_points.spatialIndex.search(searchRect));
-		potentialPts = potentialPts.concat(MASSGIS.selectionLayer.spatialIndex.search(searchRect));
-		potentialPts = potentialPts.concat(MASSGIS.preSelectionLayer.spatialIndex.search(searchRect));
-
-		var vettedPotentialPts = [];
-
-		$.each(potentialPts, function(idx, mpt) {
-			if (mpt.attributes &&
-				(
-					mpt.attributes.point_type == 'GC' ||
-					mpt.attributes.geographic_edit_status == 'DELETED' ||
-					(mpt.attributes.type_icon == 'NONE' && mpt.attributes.status_color == 'NONE')
-				)
-			) {
-				return;
+				});
 			}
-			vettedPotentialPts.push(mpt);
+
+			MASSGIS.pointsSelected(selAddrs, clickedPt, buffer);
+			fixgeometry();
 		});
-		potentialPts = vettedPotentialPts;
-
-		// Go through potentialPts and look at each one's component(s) to see if the tapped point is w/i a certain distance.
-		// Don't want to click in a fair-game blank space in the middle of a MP and be unable to do anything.
-		var pp = [];
-		for (var i = 0; i < potentialPts.length; i++) {
-			var pass_thru = true;
-			var c = potentialPts[i].geometry.components;
-			for (var j = 0; j < c.length; j++) {
-				pass_thru = pass_thru && c[j].distanceTo(new OpenLayers.Geometry.Point(clickedPt.lon,clickedPt.lat)) > 15;
-			}
-			if (!pass_thru) {
-				pp.push(potentialPts[i]);
-			}
-		}
-		potentialPts = pp ? pp : potentialPts;
-
-		var tappedOnAPoint = potentialPts.length > 0;
-
-		if (!tappedOnAPoint && MASSGIS.preSelectionLayer.features.length === 1 && MASSGIS.selectionLayer.features.length === 0) {
-			var conf = confirm("Add a new part to the selected Address Point?");
-			if (!conf) {
-				return;
-			}
-			var newFeature = MASSGIS.wktReader.read("MULTIPOINT(" + clickedPt.lon + " " + clickedPt.lat + ")");
-			MASSGIS.preSelectionLayer.features[0].geometry.components.push(newFeature.geometry.components[0].clone());
-			MASSGIS.preSelectionLayer.features[0].geometry.calculateBounds();
-			MASSGIS.preSelectionLayer.events.triggerEvent(
-				"featuremodified",
-				{
-					object:MASSGIS.preSelectionLayer,
-					feature: MASSGIS.preSelectionLayer.features[0]
-				}
-			);
-
-			var existingFeature = MASSGIS.lyr_address_points.getFeaturesByAttribute("address_point_id",MASSGIS.preSelectionLayer.features[0].attributes.address_point_id);
-			existingFeature[0].geometry.components.push(newFeature.geometry.components[0].clone());
-			existingFeature[0].geometry.calculateBounds();
-			existingFeature[0].attributes.__MODIFIED__ = true;
-			existingFeature[0].attributes.geographic_edit_status = 'MODIFIED';
-			existingFeature[0].attributes.transaction_id = MASSGIS.generateTXId();
-			existingFeature[0].attributes.time_stamp = new Date().toTimeString().split(" ")[0];
-			existingFeature[0].state = OpenLayers.State.UPDATE;
-			MASSGIS.lyr_address_points.strategies[1].save();
-			MASSGIS.lyr_address_points.events.triggerEvent(
-				"featuremodified",
-				{
-					object:MASSGIS.lyr_address_points,
-					feature: existingFeature[0]
-				}
-			);
-
-			MASSGIS.preSelectionLayer.redraw();
-			MASSGIS.lyr_address_points.redraw();
-		} else if (!tappedOnAPoint && MASSGIS.preSelectionLayer.features.length === 0 && MASSGIS.selectionLayer.features.length === 0) {
-			var conf = confirm("Add a new Address Point at this location?");
-			if (!conf) {
+		MASSGIS.wktReader = new OpenLayers.Format.WKT();
+		click.events.register("clickhold", {}, function (e) {
+			// no long-tap actions if we're over the max resolution of the address points layer
+			if (MASSGIS.map.getResolution() > MASSGIS.lyr_address_points.maxResolution) {
 				return;
 			}
 
-			// Create new address_point_id in MASSGIS-friendly projection coords.
-			var newLonLat = new OpenLayers.LonLat(clickedPt.lon,clickedPt.lat).transform(
-				 MASSGIS.map.getProjectionObject()
-				,new OpenLayers.Projection('EPSG:26986')
-			);
+			// find all the points we long-tapped on
+			var clickedPt = MASSGIS.map.getLonLatFromPixel(e.evt.xy);
+			var buffer = MASSGIS.map.getResolution() * MASSGIS.config.tapTolerance;
+			var searchRect = { x: clickedPt.lon - buffer, y: clickedPt.lat - buffer, w: buffer * 2, h: buffer * 2 }
 
-			var newFeature = MASSGIS.wktReader.read("MULTIPOINT(" + clickedPt.lon + " " + clickedPt.lat + ")");
-			newFeature.attributes.address_point_id = 'M_' + Math.round(newLonLat.lon) + '_' + Math.round(newLonLat.lat);
-			newFeature.attributes.status_color = "RED";
-			newFeature.attributes.address_status = "UNLINKED";
-			newFeature.attributes.geographic_edit_status = "ADDED";
-			newFeature.attributes.structure_type = "M";
-			newFeature.attributes.type_icon = "CIRCLE";
-			newFeature.attributes.label_text = "";
-			var communityId = $('#msag_community').val();
-			if (!communityId || communityId == '') {
-				if (!MASSGIS.lyr_address_points.features) {
-					communityId = -1;
-				} else {
-					communityId = MASSGIS.lyr_address_points.features[0].attributes.community_id;
+			var potentialPts = [];
+			potentialPts = potentialPts.concat(MASSGIS.lyr_address_points.spatialIndex.search(searchRect));
+			potentialPts = potentialPts.concat(MASSGIS.selectionLayer.spatialIndex.search(searchRect));
+			potentialPts = potentialPts.concat(MASSGIS.preSelectionLayer.spatialIndex.search(searchRect));
+
+			var vettedPotentialPts = [];
+
+			$.each(potentialPts, function (idx, mpt) {
+				if (mpt.attributes &&
+					(
+						mpt.attributes.point_type == 'GC' ||
+						mpt.attributes.geographic_edit_status == 'DELETED' ||
+						(mpt.attributes.type_icon == 'NONE' && mpt.attributes.status_color == 'NONE')
+					)
+				) {
+					return;
 				}
-				if (!communityId || communityId == '') {
-					communityId = -1;
+				vettedPotentialPts.push(mpt);
+			});
+			potentialPts = vettedPotentialPts;
+
+			// Go through potentialPts and look at each one's component(s) to see if the tapped point is w/i a certain distance.
+			// Don't want to click in a fair-game blank space in the middle of a MP and be unable to do anything.
+			var pp = [];
+			for (var i = 0; i < potentialPts.length; i++) {
+				var pass_thru = true;
+				var c = potentialPts[i].geometry.components;
+				for (var j = 0; j < c.length; j++) {
+					pass_thru = pass_thru && c[j].distanceTo(new OpenLayers.Geometry.Point(clickedPt.lon, clickedPt.lat)) > 15;
+				}
+				if (!pass_thru) {
+					pp.push(potentialPts[i]);
 				}
 			}
-			if (communityId == -1) {
-				alert("Unable to locate an MSAG community_id for your new address point.  The community_id will be assigned after the point is added to the database.");
-			}
+			potentialPts = pp ? pp : potentialPts;
 
-			//newFeature.attributes.community_id = $('#msag_community').val();
-			newFeature.attributes.community_id = communityId;
-			newFeature.attributes.point_type = "ABC";
-			newFeature.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
-			//newFeature.attributes.geographic_town_id = MASSGIS.lyr_address_points.features[0].attributes.geographic_town_id;
+			var tappedOnAPoint = potentialPts.length > 0;
 
-			// Per discussion on 9/4, newly added points without connected addresses *should* be sent to server
-			// if this is not desired, comment out next line
-			newFeature.attributes.__MODIFIED__ = true;
-			newFeature.state = OpenLayers.State.INSERT;
-
-			MASSGIS.lyr_address_points.addFeatures([newFeature]);
-			MASSGIS.lyr_address_points.strategies[1].save();
-			MASSGIS.lyr_address_points.redraw();
-		} else if (tappedOnAPoint) {
-			$('#delete_or_ignore_popup').popup().popup("open");
-			$('#delete_or_ignore_popup a[data-icon=delete]').on("click",function(e) {
-				$('#delete_or_ignore_popup a[data-icon=delete]').off("click");
-				$('#delete_or_ignore_popup a[data-icon=minus]').off("click");
-				MASSGIS.undoStack = {
-					 action		: 'delete_address_point'
-					,f			: []
-				};
-				var txId = MASSGIS.generateTXId();
-				var deletedComponents = [];
-				$.each(potentialPts, function(idx, targetMP) {
-					if (targetMP.layer !== MASSGIS.lyr_address_points) return;
-
-					var targetMPClone = targetMP.clone();
-					targetMPClone.fid = targetMP.fid;
-					targetMPClone.layer = targetMP.layer;
-					$.each(targetMP.geometry.components, function(idx, component) {
-						if (component && component.distanceTo(new OpenLayers.Geometry.Point(clickedPt.lon,clickedPt.lat)) < buffer) {
-							var delPt = targetMP.geometry.components.splice(idx, 1);
-							deletedComponents = deletedComponents.concat(delPt);
-							targetMP.attributes.geographic_edit_status = 'MODIFIED';
-							targetMP.attributes.__MODIFIED__ = true;
-							targetMP.attributes.transaction_id = txId;
-							targetMP.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
-							targetMP.state = OpenLayers.State.UPDATE;
+			if (!tappedOnAPoint && MASSGIS.preSelectionLayer.features.length === 1 && MASSGIS.selectionLayer.features.length === 0) {
+				$('#confirm_add_multi_part_popup').popup().popup("open");
+				$('#confirm_add_multi_part_popup a[data-icon=plus]').on("click", function (e) {
+					var newFeature = MASSGIS.wktReader.read("MULTIPOINT(" + clickedPt.lon + " " + clickedPt.lat + ")");
+					MASSGIS.preSelectionLayer.features[0].geometry.components.push(newFeature.geometry.components[0].clone());
+					MASSGIS.preSelectionLayer.features[0].geometry.calculateBounds();
+					MASSGIS.preSelectionLayer.events.triggerEvent(
+						"featuremodified",
+						{
+							object: MASSGIS.preSelectionLayer,
+							feature: MASSGIS.preSelectionLayer.features[0]
 						}
-					});
-					var fullDelete = false;
-					if (targetMP.geometry.components.length === 0) {
-						var fullDelete = true;
-						// we deleted the entire geometry.  Mark the feature deleted
-						targetMP.geometry.components = deletedComponents;
-						targetMP.attributes.geographic_edit_status = 'DELETED';
-						targetMP.attributes.status_color = 'NONE';
-						targetMP.attributes.transaction_id = txId;
-						targetMP.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
-						targetMP.state = OpenLayers.State.UPDATE;
+					);
 
-						// we also need to mark any address records that were originally associated with this
-						// point as address_point_id = null
-						$.each(MASSGIS.lyr_maf.getFeaturesByAttribute("address_point_id",targetMP.attributes.address_point_id), function(idx, madRec) {
-							madRec.attributes.status_color = 'RED';
-							madRec.attributes.address_point_id = '';
-							madRec.attributes.address_status = 'UNLINKED';
-							madRec.attributes.__MODIFIED__ = true;
-							madRec.attributes.transaction_id = txId;
-							madRec.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
-							madRec.state = OpenLayers.State.UPDATE;
-						});
-						MASSGIS.lyr_maf.strategies[1].save();
-						MASSGIS.renderAddressList();
-
-					} else {
-						// we deleted SOME of the components of this point.  We need to split the point out and create the corresponding point that has the deletes in it
-						var delClone = targetMP.clone();
-						delClone.fid = null;
-						delClone.layer = targetMP.layer;
-						delClone.geometry.components = deletedComponents;
-						var newCentroid = delClone.geometry.getCentroid().clone().transform(
-							 MASSGIS.map.getProjectionObject()
-							,new OpenLayers.Projection('EPSG:26986')
-						);
-						delClone.attributes.address_point_id = "M_" + Math.round(newCentroid.x) + "_" + Math.round(newCentroid.y);
-						delClone.attributes.status_color = 'NONE';
-						delClone.attributes.geographic_edit_status = 'DELETED';
-						delClone.attributes.__MODIFIED__ = true;
-						delClone.attributes.transaction_id = txId;
-						delClone.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
-
-						delClone.state = OpenLayers.State.INSERT;
-						MASSGIS.lyr_address_points.addFeatures([delClone]);
-						//MASSGIS.lyr_address_points.strategies[1].save();
-						//MASSGIS.lyr_address_points.reindex();
-					}
-					if (targetMP.state == OpenLayers.State.UPDATE) {
-						// only want to push the MP to the stack if it was modified
-						MASSGIS.undoStack.f.push(targetMPClone);
-					}
-
-					// also clear out the pre-selected or selected version of this point
-					var presel = MASSGIS.preSelectionLayer.getFeaturesByAttribute("address_point_id",targetMP.attributes.address_point_id);
-					if (presel.length > 0 ) {
-						MASSGIS.preSelectionLayer.removeFeatures(presel);
-						if (!fullDelete) {
-							MASSGIS.preSelectionLayer.addFeatures([targetMP.clone()]);
+					var existingFeature = MASSGIS.lyr_address_points.getFeaturesByAttribute("address_point_id", MASSGIS.preSelectionLayer.features[0].attributes.address_point_id);
+					existingFeature[0].geometry.components.push(newFeature.geometry.components[0].clone());
+					existingFeature[0].geometry.calculateBounds();
+					existingFeature[0].attributes.__MODIFIED__ = true;
+					existingFeature[0].attributes.geographic_edit_status = 'MODIFIED';
+					existingFeature[0].attributes.transaction_id = MASSGIS.generateTXId();
+					existingFeature[0].attributes.time_stamp = new Date().toTimeString().split(" ")[0];
+					existingFeature[0].state = OpenLayers.State.UPDATE;
+					MASSGIS.lyr_address_points.strategies[1].save();
+					MASSGIS.lyr_address_points.events.triggerEvent(
+						"featuremodified",
+						{
+							object: MASSGIS.lyr_address_points,
+							feature: existingFeature[0]
 						}
-					}
-
-					var sel = MASSGIS.selectionLayer.getFeaturesByAttribute("address_point_id",targetMP.attributes.address_point_id);
-					if (sel.length > 0) {
-						MASSGIS.selectionLayer.removeFeatures(sel);
-						// if (!fullDelete) {
-						// 	MASSGIS.selectionLayer.addFeatures([targetMP.clone()]);
-						// }
-					}
+					);
 
 					MASSGIS.preSelectionLayer.redraw();
-					MASSGIS.selectionLayer.redraw();
-
-					targetMP.layer.strategies && targetMP.layer.strategies[1].save();
-					targetMP.layer.redraw();
-					targetMP.layer.spatialIndex && targetMP.layer.reindex();
+					MASSGIS.lyr_address_points.redraw();
 				});
-			});
+			} else if (!tappedOnAPoint && MASSGIS.preSelectionLayer.features.length === 0 && MASSGIS.selectionLayer.features.length === 0) {
+				var conf = confirm("Add a new Address Point at this location?");
+				if (!conf) {
+					return;
+				}
 
-			$('#delete_or_ignore_popup a[data-icon=minus]').on("click",function(e) {
-				$('#delete_or_ignore_popup a[data-icon=delete]').off("click");
-				$('#delete_or_ignore_popup a[data-icon=minus]').off("click");
-				MASSGIS.undoStack = {
-					 action		: 'ignore_address_point'
-					,f			: []
-					,madRecIds	: []
-				};
-				var txId = MASSGIS.generateTXId();
-				$.each(potentialPts, function(idx, targetMP) {
-					var targetMPClone = targetMP.clone();
-					targetMPClone.fid = targetMP.fid;
-					targetMPClone.layer = targetMP.layer;
-					var secondaryPointCoords = [];
-					$.each(targetMP.geometry.components, function(idx, component) {
-						if (component && component.distanceTo(new OpenLayers.Geometry.Point(clickedPt.lon,clickedPt.lat)) < buffer) {
-							secondaryPointCoords.push(targetMP.geometry.components.splice(idx, 1)[0]);
-							targetMP.attributes.geographic_edit_status = 'SPLIT';
+				// Create new address_point_id in MASSGIS-friendly projection coords.
+				var newLonLat = new OpenLayers.LonLat(clickedPt.lon, clickedPt.lat).transform(
+					MASSGIS.map.getProjectionObject()
+					, new OpenLayers.Projection('EPSG:26986')
+				);
+
+				var newFeature = MASSGIS.wktReader.read("MULTIPOINT(" + clickedPt.lon + " " + clickedPt.lat + ")");
+				newFeature.attributes.address_point_id = 'M_' + Math.round(newLonLat.lon) + '_' + Math.round(newLonLat.lat);
+				newFeature.attributes.status_color = "RED";
+				newFeature.attributes.address_status = "UNLINKED";
+				newFeature.attributes.geographic_edit_status = "ADDED";
+				newFeature.attributes.structure_type = "M";
+				newFeature.attributes.type_icon = "CIRCLE";
+				newFeature.attributes.label_text = "";
+				var communityId = $('#msag_community').val();
+				if (!communityId || communityId == '') {
+					if (!MASSGIS.lyr_address_points.features) {
+						communityId = -1;
+					} else {
+						communityId = MASSGIS.lyr_address_points.features[0].attributes.community_id;
+					}
+					if (!communityId || communityId == '') {
+						communityId = -1;
+					}
+				}
+				if (communityId == -1) {
+					alert("Unable to locate an MSAG community_id for your new address point.  The community_id will be assigned after the point is added to the database.");
+				}
+
+				//newFeature.attributes.community_id = $('#msag_community').val();
+				newFeature.attributes.community_id = communityId;
+				newFeature.attributes.point_type = "ABC";
+				newFeature.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
+				//newFeature.attributes.geographic_town_id = MASSGIS.lyr_address_points.features[0].attributes.geographic_town_id;
+
+				// Per discussion on 9/4, newly added points without connected addresses *should* be sent to server
+				// if this is not desired, comment out next line
+				newFeature.attributes.__MODIFIED__ = true;
+				newFeature.state = OpenLayers.State.INSERT;
+
+				MASSGIS.lyr_address_points.addFeatures([newFeature]);
+				MASSGIS.lyr_address_points.strategies[1].save();
+				MASSGIS.lyr_address_points.redraw();
+			} else if (tappedOnAPoint) {
+				$('#delete_or_ignore_popup').popup().popup("open");
+				$('#delete_or_ignore_popup a[data-icon=delete]').on("click", function (e) {
+					$('#delete_or_ignore_popup a[data-icon=delete]').off("click");
+					$('#delete_or_ignore_popup a[data-icon=minus]').off("click");
+					MASSGIS.undoStack = {
+						action: 'delete_address_point'
+						, f: []
+					};
+					var txId = MASSGIS.generateTXId();
+					var deletedComponents = [];
+					$.each(potentialPts, function (idx, targetMP) {
+						if (targetMP.layer !== MASSGIS.lyr_address_points) return;
+
+						var targetMPClone = targetMP.clone();
+						targetMPClone.fid = targetMP.fid;
+						targetMPClone.layer = targetMP.layer;
+						$.each(targetMP.geometry.components, function (idx, component) {
+							if (component && component.distanceTo(new OpenLayers.Geometry.Point(clickedPt.lon, clickedPt.lat)) < buffer) {
+								var delPt = targetMP.geometry.components.splice(idx, 1);
+								deletedComponents = deletedComponents.concat(delPt);
+								targetMP.attributes.geographic_edit_status = 'MODIFIED';
+								targetMP.attributes.__MODIFIED__ = true;
+								targetMP.attributes.transaction_id = txId;
+								targetMP.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
+								targetMP.state = OpenLayers.State.UPDATE;
+							}
+						});
+						var fullDelete = false;
+						if (targetMP.geometry.components.length === 0) {
+							var fullDelete = true;
+							// we deleted the entire geometry.  Mark the feature deleted
+							targetMP.geometry.components = deletedComponents;
+							targetMP.attributes.geographic_edit_status = 'DELETED';
+							targetMP.attributes.status_color = 'NONE';
 							targetMP.attributes.transaction_id = txId;
 							targetMP.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
-							targetMP.attributes.__MODIFIED__ = true;
 							targetMP.state = OpenLayers.State.UPDATE;
-						}
-					});
-					if (targetMP.geometry.components.length === 0) {
-						if (targetMP.layer == MASSGIS.preSelectionLayer || targetMP.layer == MASSGIS.selectionLayer) {
-							targetMP.layer.removeFeatures([targetMP]);
-						} else {
-							// we marked the entire geometry as SECONDARY, no need to do a split
-							targetMP.attributes.geographic_edit_status = 'UNLINKED';
-							targetMP.attributes.status_color = 'GRAY';
-							targetMP.attributes.transaction_id = txId;
-							targetMP.attributes.structure_status = 'S';
-							targetMP.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
-							targetMP.attributes.__MODIFIED__ = true;
-							targetMP.state = OpenLayers.State.UPDATE;
-							targetMP.geometry.components = secondaryPointCoords;
 
 							// we also need to mark any address records that were originally associated with this
 							// point as address_point_id = null
-							$.each(MASSGIS.lyr_maf.getFeaturesByAttribute("address_point_id",targetMP.attributes.address_point_id), function(idx, madRec) {
+							$.each(MASSGIS.lyr_maf.getFeaturesByAttribute("address_point_id", targetMP.attributes.address_point_id), function (idx, madRec) {
 								madRec.attributes.status_color = 'RED';
 								madRec.attributes.address_point_id = '';
 								madRec.attributes.address_status = 'UNLINKED';
+								madRec.attributes.__MODIFIED__ = true;
 								madRec.attributes.transaction_id = txId;
 								madRec.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
-								madRec.attributes.__MODIFIED__ = true;
-								MASSGIS.undoStack.madRecIds.push(madRec.master_address_id);
+								madRec.state = OpenLayers.State.UPDATE;
 							});
 							MASSGIS.lyr_maf.strategies[1].save();
 							MASSGIS.renderAddressList();
+
+						} else {
+							// we deleted SOME of the components of this point.  We need to split the point out and create the corresponding point that has the deletes in it
+							var delClone = targetMP.clone();
+							delClone.fid = null;
+							delClone.layer = targetMP.layer;
+							delClone.geometry.components = deletedComponents;
+							var newCentroid = delClone.geometry.getCentroid().clone().transform(
+								MASSGIS.map.getProjectionObject()
+								, new OpenLayers.Projection('EPSG:26986')
+							);
+							delClone.attributes.address_point_id = "M_" + Math.round(newCentroid.x) + "_" + Math.round(newCentroid.y);
+							delClone.attributes.status_color = 'NONE';
+							delClone.attributes.geographic_edit_status = 'DELETED';
+							delClone.attributes.__MODIFIED__ = true;
+							delClone.attributes.transaction_id = txId;
+							delClone.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
+
+							delClone.state = OpenLayers.State.INSERT;
+							MASSGIS.lyr_address_points.addFeatures([delClone]);
+							//MASSGIS.lyr_address_points.strategies[1].save();
+							//MASSGIS.lyr_address_points.reindex();
 						}
-					} else if (targetMP.layer == MASSGIS.lyr_address_points) {
-						var newPoint = targetMP.clone();
-						delete newPoint.fid;
-						newPoint.geometry.components = secondaryPointCoords;
-						var newCentroid = newPoint.geometry.getCentroid().clone().transform(
-							 MASSGIS.map.getProjectionObject()
-							,new OpenLayers.Projection('EPSG:26986')
-						);
-						newPoint.attributes.address_point_id = "M_" + Math.round(newCentroid.x) + "_" + Math.round(newCentroid.y);
-						newPoint.attributes.status_color = "GRAY";
-						newPoint.attributes.address_status = "UNLINKED";
-						newPoint.attributes.geographic_edit_status = "SPLIT";
-						newPoint.attributes.structure_status = "S";
-						newPoint.attributes.label_text = "";
-						newPoint.attributes.site_id	= targetMP.attributes.site_id;
-						newPoint.attributes.community_id = targetMP.attributes.community_id;
-						newPoint.attributes.loc_id = targetMP.attributes.loc_id;
-						newPoint.attributes.geographic_town_id = targetMP.attributes.geographic_town_id;
-						newPoint.attributes.transaction_id = txId;
-						newPoint.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
-						newPoint.attributes.__MODIFIED__ = true;
-						newPoint.state = OpenLayers.State.INSERT;
+						if (targetMP.state == OpenLayers.State.UPDATE) {
+							// only want to push the MP to the stack if it was modified
+							MASSGIS.undoStack.f.push(targetMPClone);
+						}
 
-						MASSGIS.lyr_address_points.addFeatures([newPoint]);
-						//MASSGIS.lyr_address_points.strategies[1].save();
+						// also clear out the pre-selected or selected version of this point
+						var presel = MASSGIS.preSelectionLayer.getFeaturesByAttribute("address_point_id", targetMP.attributes.address_point_id);
+						if (presel.length > 0) {
+							MASSGIS.preSelectionLayer.removeFeatures(presel);
+							if (!fullDelete) {
+								MASSGIS.preSelectionLayer.addFeatures([targetMP.clone()]);
+							}
+						}
 
-						MASSGIS.undoStack.newPoint = newPoint;
-					}
-					if (targetMP.state == OpenLayers.State.UPDATE) {
-						// only want to push the MP to the stack if it was modified
-						MASSGIS.undoStack.f.push(targetMPClone);
-					}
-					targetMP.layer && targetMP.layer.strategies && targetMP.layer.strategies[1].save();
-					targetMP.layer && targetMP.layer.redraw();
-					targetMP.layer && targetMP.layer.spatialIndex && targetMP.layer.reindex();
+						var sel = MASSGIS.selectionLayer.getFeaturesByAttribute("address_point_id", targetMP.attributes.address_point_id);
+						if (sel.length > 0) {
+							MASSGIS.selectionLayer.removeFeatures(sel);
+							// if (!fullDelete) {
+							// 	MASSGIS.selectionLayer.addFeatures([targetMP.clone()]);
+							// }
+						}
+
+						MASSGIS.preSelectionLayer.redraw();
+						MASSGIS.selectionLayer.redraw();
+
+						targetMP.layer.strategies && targetMP.layer.strategies[1].save();
+						targetMP.layer.redraw();
+						targetMP.layer.spatialIndex && targetMP.layer.reindex();
+					});
 				});
-			});
-		} else {
-			alert("Please add any points you wish to add *before* selecting points for linking");
+
+				$('#delete_or_ignore_popup a[data-icon=minus]').on("click", function (e) {
+					$('#delete_or_ignore_popup a[data-icon=delete]').off("click");
+					$('#delete_or_ignore_popup a[data-icon=minus]').off("click");
+					MASSGIS.undoStack = {
+						action: 'ignore_address_point'
+						, f: []
+						, madRecIds: []
+					};
+					var txId = MASSGIS.generateTXId();
+					$.each(potentialPts, function (idx, targetMP) {
+						var targetMPClone = targetMP.clone();
+						targetMPClone.fid = targetMP.fid;
+						targetMPClone.layer = targetMP.layer;
+						var secondaryPointCoords = [];
+						$.each(targetMP.geometry.components, function (idx, component) {
+							if (component && component.distanceTo(new OpenLayers.Geometry.Point(clickedPt.lon, clickedPt.lat)) < buffer) {
+								secondaryPointCoords.push(targetMP.geometry.components.splice(idx, 1)[0]);
+								targetMP.attributes.geographic_edit_status = 'SPLIT';
+								targetMP.attributes.transaction_id = txId;
+								targetMP.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
+								targetMP.attributes.__MODIFIED__ = true;
+								targetMP.state = OpenLayers.State.UPDATE;
+							}
+						});
+						if (targetMP.geometry.components.length === 0) {
+							if (targetMP.layer == MASSGIS.preSelectionLayer || targetMP.layer == MASSGIS.selectionLayer) {
+								targetMP.layer.removeFeatures([targetMP]);
+							} else {
+								// we marked the entire geometry as SECONDARY, no need to do a split
+								targetMP.attributes.geographic_edit_status = 'UNLINKED';
+								targetMP.attributes.status_color = 'GRAY';
+								targetMP.attributes.transaction_id = txId;
+								targetMP.attributes.structure_status = 'S';
+								targetMP.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
+								targetMP.attributes.__MODIFIED__ = true;
+								targetMP.state = OpenLayers.State.UPDATE;
+								targetMP.geometry.components = secondaryPointCoords;
+
+								// we also need to mark any address records that were originally associated with this
+								// point as address_point_id = null
+								$.each(MASSGIS.lyr_maf.getFeaturesByAttribute("address_point_id", targetMP.attributes.address_point_id), function (idx, madRec) {
+									madRec.attributes.status_color = 'RED';
+									madRec.attributes.address_point_id = '';
+									madRec.attributes.address_status = 'UNLINKED';
+									madRec.attributes.transaction_id = txId;
+									madRec.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
+									madRec.attributes.__MODIFIED__ = true;
+									MASSGIS.undoStack.madRecIds.push(madRec.master_address_id);
+								});
+								MASSGIS.lyr_maf.strategies[1].save();
+								MASSGIS.renderAddressList();
+							}
+						} else if (targetMP.layer == MASSGIS.lyr_address_points) {
+							var newPoint = targetMP.clone();
+							delete newPoint.fid;
+							newPoint.geometry.components = secondaryPointCoords;
+							var newCentroid = newPoint.geometry.getCentroid().clone().transform(
+								MASSGIS.map.getProjectionObject()
+								, new OpenLayers.Projection('EPSG:26986')
+							);
+							newPoint.attributes.address_point_id = "M_" + Math.round(newCentroid.x) + "_" + Math.round(newCentroid.y);
+							newPoint.attributes.status_color = "GRAY";
+							newPoint.attributes.address_status = "UNLINKED";
+							newPoint.attributes.geographic_edit_status = "SPLIT";
+							newPoint.attributes.structure_status = "S";
+							newPoint.attributes.label_text = "";
+							newPoint.attributes.site_id = targetMP.attributes.site_id;
+							newPoint.attributes.community_id = targetMP.attributes.community_id;
+							newPoint.attributes.loc_id = targetMP.attributes.loc_id;
+							newPoint.attributes.geographic_town_id = targetMP.attributes.geographic_town_id;
+							newPoint.attributes.transaction_id = txId;
+							newPoint.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
+							newPoint.attributes.__MODIFIED__ = true;
+							newPoint.state = OpenLayers.State.INSERT;
+
+							MASSGIS.lyr_address_points.addFeatures([newPoint]);
+							//MASSGIS.lyr_address_points.strategies[1].save();
+
+							MASSGIS.undoStack.newPoint = newPoint;
+						}
+						if (targetMP.state == OpenLayers.State.UPDATE) {
+							// only want to push the MP to the stack if it was modified
+							MASSGIS.undoStack.f.push(targetMPClone);
+						}
+						targetMP.layer && targetMP.layer.strategies && targetMP.layer.strategies[1].save();
+						targetMP.layer && targetMP.layer.redraw();
+						targetMP.layer && targetMP.layer.spatialIndex && targetMP.layer.reindex();
+					});
+				});
+			} else {
+				alert("Please add any points you wish to add *before* selecting points for linking");
+				return;
+			}
+
+		});
+
+		MASSGIS.map.addControl(click);
+		click.activate();
+
+		$('#layer_switcher').on('click', function () {
+			MASSGIS.mapType = MASSGIS.mapTypes[(_.indexOf(MASSGIS.mapTypes, MASSGIS.mapType) + 1) % MASSGIS.mapTypes.length];
+			if (MASSGIS.mapType == 'Road') {
+				//MASSGIS.map.setBaseLayer(MASSGIS.osmLayer);
+				MASSGIS.map.setBaseLayer(MASSGIS.topoBasemap);
+				jQuery('.ui-icon.ui-icon-shadow.ui-icon-mft-sattelite')
+					.css('background-image', 'url("img/sattelite_icon.png")')
+					.css('width', '81px');
+				jQuery('#layer_switcher .ui-btn-text').html('MassGIS');
+			}
+			else if (MASSGIS.mapType == 'Ortho 2013-14') {
+				MASSGIS.map.setBaseLayer(MASSGIS.mgisOrthosStatewideLayer2014);
+				jQuery('.ui-icon.ui-icon-shadow.ui-icon-mft-sattelite')
+					.css('background-image', 'url("img/sattelite_icon.png")')
+					.css('width', '74px');
+				jQuery('#layer_switcher .ui-btn-text').html('Google');
+			}
+			else if (MASSGIS.mapType == 'Ortho 2014-15') {
+				MASSGIS.map.setBaseLayer(MASSGIS.mgisOrthosStatewideLayer2015);
+				jQuery('.ui-icon.ui-icon-shadow.ui-icon-mft-sattelite')
+					.css('background-image', 'url("img/blankBase_icon.png")')
+					.css('text-color', 'black')
+					.css('width', '65px');
+				jQuery('#layer_switcher .ui-btn-text').html('blank');
+			} else if (MASSGIS.mapType == 'Blank') {
+				MASSGIS.map.setBaseLayer(MASSGIS.blankBaseLayer);
+				jQuery('.ui-icon.ui-icon-shadow.ui-icon-mft-sattelite').css('background-image', 'url("img/streets_icon.png")');
+				jQuery('.ui-icon.ui-icon-shadow.ui-icon-mft-sattelite')
+					.css('text-color', 'black')
+					.css('width', '74px');
+				jQuery('#layer_switcher .ui-btn-text').html('streets');
+			}
+		});
+
+		$('#zoom_out').on('click', function () {
+			MASSGIS.map.zoomOut();
+		});
+		$('#zoom_in').on('click', function () {
+			MASSGIS.map.zoomIn();
+		});
+
+		MASSGIS.map.events.register('moveend', this, function () {
+			if ($('#search_proximity').hasClass('ui-btn-active')) {
+				$('#search_proximity').trigger('click');
+				$('#addr_list > div').scrollTo(0);
+			}
+		});
+	};
+
+	MASSGIS.pointsSelected = function (aFeatures, clickedPt, buffer) {
+		if (!aFeatures) {
 			return;
 		}
-
-	});
-
-	MASSGIS.map.addControl(click);
-	click.activate();
-
-	$('#layer_switcher').on('click', function() {
-		MASSGIS.mapType = MASSGIS.mapTypes[(_.indexOf(MASSGIS.mapTypes,MASSGIS.mapType) + 1) % MASSGIS.mapTypes.length];
-		if (MASSGIS.mapType == 'Road') {
-			//MASSGIS.map.setBaseLayer(MASSGIS.osmLayer);
-			MASSGIS.map.setBaseLayer(MASSGIS.topoBasemap);
-			jQuery('.ui-icon.ui-icon-shadow.ui-icon-mft-sattelite')
-				.css('background-image','url("img/sattelite_icon.png")')
-				.css('width','81px');
-			jQuery('#layer_switcher .ui-btn-text').html('MassGIS');
-		}
-		else if (MASSGIS.mapType == 'Ortho 2013-14') {
-			MASSGIS.map.setBaseLayer(MASSGIS.mgisOrthosStatewideLayer2014);
-			jQuery('.ui-icon.ui-icon-shadow.ui-icon-mft-sattelite')
-				.css('background-image','url("img/sattelite_icon.png")')
-				.css('width','74px');
-			jQuery('#layer_switcher .ui-btn-text').html('Google');
-		}
-		else if (MASSGIS.mapType == 'Ortho 2014-15') {
-			MASSGIS.map.setBaseLayer(MASSGIS.mgisOrthosStatewideLayer2015);
-			jQuery('.ui-icon.ui-icon-shadow.ui-icon-mft-sattelite')
-				.css('background-image','url("img/blankBase_icon.png")')
-				.css('text-color','black')
-				.css('width','65px');
-			jQuery('#layer_switcher .ui-btn-text').html('blank');
-		} else if (MASSGIS.mapType == 'Blank') {
-			MASSGIS.map.setBaseLayer(MASSGIS.blankBaseLayer);
-			jQuery('.ui-icon.ui-icon-shadow.ui-icon-mft-sattelite').css('background-image','url("img/streets_icon.png")');
-			jQuery('.ui-icon.ui-icon-shadow.ui-icon-mft-sattelite')
-				.css('text-color','black')
-				.css('width','74px');
-			jQuery('#layer_switcher .ui-btn-text').html('streets');
-		}
-	});
-
-	$('#zoom_out').on('click', function() {
-		MASSGIS.map.zoomOut();
-	});
-	$('#zoom_in').on('click', function() {
-		MASSGIS.map.zoomIn();
-	});
-
-	MASSGIS.map.events.register('moveend',this,function() {
-		if ($('#search_proximity').hasClass('ui-btn-active')) {
-			$('#search_proximity').trigger('click');
-			$('#addr_list > div').scrollTo(0);
-		}
-		});
-};
-
-MASSGIS.pointsSelected = function(aFeatures, clickedPt, buffer) {
-	if (!aFeatures) {
-		return;
-	}
-	$.each(aFeatures, function(idx, oPoint) {
-		var p = oPoint.clone();
-		p.style = null;
-		MASSGIS.map.setLayerZIndex(MASSGIS.preSelectionLayer, 6);
-		MASSGIS.map.setLayerZIndex(MASSGIS.selectionLayer, 12);
-		var preSelectionPt = MASSGIS.preSelectionLayer.getFeaturesByAttribute("address_point_id",oPoint.attributes.address_point_id);
-		var potentialSelectionPts = MASSGIS.selectionLayer.getFeaturesByAttribute("address_point_id",oPoint.attributes.address_point_id);
-		var selectionPts = [];
-		// neeed to be more specific on the selectionPts part.  Did we actually CLICK on a selection point?
-		$.each(potentialSelectionPts, function(idx, selPt) {
-			if (selPt.geometry.components[0].distanceTo(new OpenLayers.Geometry.Point(clickedPt.lon,clickedPt.lat)) < buffer) {
-				selectionPts.push(selPt);
-			}
-		});
-		if (selectionPts.length > 0) {
-			// we clicked on a selection point.  Put it "back" with its corresponding pre-selection point.
-			MASSGIS.selectionLayer.removeFeatures(selectionPts);
-			$.each(selectionPts, function(idx, selPt) {
-				var preSelectionPt = MASSGIS.preSelectionLayer.getFeaturesByAttribute("address_point_id",selPt.attributes.address_point_id);
-				if (preSelectionPt.length > 0) {
-					// add this component back to its parent "pre-selection" point
-					preSelectionPt[0].geometry.components = preSelectionPt[0].geometry.components.concat(selPt.geometry.components);
-				} else {
-					// just move it back over to the pre-selection layer
-					selPt.style = null;
-					MASSGIS.preSelectionLayer.addFeatures([selPt]);
+		$.each(aFeatures, function (idx, oPoint) {
+			var p = oPoint.clone();
+			p.style = null;
+			MASSGIS.map.setLayerZIndex(MASSGIS.preSelectionLayer, 6);
+			MASSGIS.map.setLayerZIndex(MASSGIS.selectionLayer, 12);
+			var preSelectionPt = MASSGIS.preSelectionLayer.getFeaturesByAttribute("address_point_id", oPoint.attributes.address_point_id);
+			var potentialSelectionPts = MASSGIS.selectionLayer.getFeaturesByAttribute("address_point_id", oPoint.attributes.address_point_id);
+			var selectionPts = [];
+			// neeed to be more specific on the selectionPts part.  Did we actually CLICK on a selection point?
+			$.each(potentialSelectionPts, function (idx, selPt) {
+				if (selPt.geometry.components[0].distanceTo(new OpenLayers.Geometry.Point(clickedPt.lon, clickedPt.lat)) < buffer) {
+					selectionPts.push(selPt);
 				}
 			});
-			MASSGIS.preSelectionLayer.redraw();
-		} else if (preSelectionPt.length > 0)  {
-			// given a pre-selected point, promote any clicked components to the selection layer
-			var preSelectionPtComponents = [];
-			var selectionPtComponents = [];
-			var point = preSelectionPt[0];
-			MASSGIS.preSelectionLayer.removeFeatures([point]);
+			if (selectionPts.length > 0) {
+				// we clicked on a selection point.  Put it "back" with its corresponding pre-selection point.
+				MASSGIS.selectionLayer.removeFeatures(selectionPts);
+				$.each(selectionPts, function (idx, selPt) {
+					var preSelectionPt = MASSGIS.preSelectionLayer.getFeaturesByAttribute("address_point_id", selPt.attributes.address_point_id);
+					if (preSelectionPt.length > 0) {
+						// add this component back to its parent "pre-selection" point
+						preSelectionPt[0].geometry.components = preSelectionPt[0].geometry.components.concat(selPt.geometry.components);
+					} else {
+						// just move it back over to the pre-selection layer
+						selPt.style = null;
+						MASSGIS.preSelectionLayer.addFeatures([selPt]);
+					}
+				});
+				MASSGIS.preSelectionLayer.redraw();
+			} else if (preSelectionPt.length > 0) {
+				// given a pre-selected point, promote any clicked components to the selection layer
+				var preSelectionPtComponents = [];
+				var selectionPtComponents = [];
+				var point = preSelectionPt[0];
+				MASSGIS.preSelectionLayer.removeFeatures([point]);
 
-			// go through each component of this pre-selected point and decide which layer to put it into.
-			$.each(point.geometry.components, function(idx, component) {
-				if (component.distanceTo(new OpenLayers.Geometry.Point(clickedPt.lon,clickedPt.lat)) < buffer) {
-					selectionPtComponents.push(point.geometry.components[idx]);
-				} else {
-					preSelectionPtComponents.push(point.geometry.components[idx]);
+				// go through each component of this pre-selected point and decide which layer to put it into.
+				$.each(point.geometry.components, function (idx, component) {
+					if (component.distanceTo(new OpenLayers.Geometry.Point(clickedPt.lon, clickedPt.lat)) < buffer) {
+						selectionPtComponents.push(point.geometry.components[idx]);
+					} else {
+						preSelectionPtComponents.push(point.geometry.components[idx]);
+					}
+				});
+
+				if (preSelectionPtComponents.length > 0) {
+					point.geometry.components = preSelectionPtComponents;
+					MASSGIS.preSelectionLayer.addFeatures([point]);
 				}
-			});
+				if (selectionPtComponents.length > 0) {
+					p.geometry.components = selectionPtComponents;
+					MASSGIS.selectionLayer.addFeatures([p]);
+				}
+			} else {
+				MASSGIS.preSelectionLayer.addFeatures([p]);
+			}
+		});
+	};
 
-			if (preSelectionPtComponents.length > 0) {
-				point.geometry.components = preSelectionPtComponents;
-				MASSGIS.preSelectionLayer.addFeatures([point]);
+	MASSGIS.init_mapExtent = function () {
+
+		if (MASSGIS.lyr_address_points.features.length > 0) {
+			var bounds = MASSGIS.lyr_address_points.getDataExtent();
+			window.setTimeout(function () {
+				MASSGIS.map.zoomToExtent(bounds, false);
+			}, 500);
+		}
+	};
+
+	$.views.tags({
+		fields: function (object, prefix) {
+			if (!prefix) {
+				prefix = '';
 			}
-			if (selectionPtComponents.length > 0) {
-				p.geometry.components = selectionPtComponents;
-				MASSGIS.selectionLayer.addFeatures([p]);
+			var key,
+				ret = "";
+			for (key in object) {
+				if (object.hasOwnProperty(key)) {
+					// For each property/field, render the content of the {{fields object}} tag, with "~key" as template parameter
+					var obj = {};
+					obj[prefix + "_key"] = key;
+					obj[prefix + "_data"] = object[key];
+					ret += this.renderContent(object[key], obj);
+				}
 			}
-		} else {
-			MASSGIS.preSelectionLayer.addFeatures([p]);
+			return ret;
 		}
 	});
-};
-
-MASSGIS.init_mapExtent = function() {
-
-	if (MASSGIS.lyr_address_points.features.length > 0) {
-		var bounds = MASSGIS.lyr_address_points.getDataExtent();
-		window.setTimeout(function() {
-			MASSGIS.map.zoomToExtent(bounds, false);
-		}, 500);
-	}
-};
-
-$.views.tags({
-	fields: function( object, prefix ) {
-		if (!prefix) {
-			prefix = '';
-		}
-		var key,
-		ret = "";
-		for ( key in object ) {
-			if ( object.hasOwnProperty( key )) {
-				// For each property/field, render the content of the {{fields object}} tag, with "~key" as template parameter
-				var obj = {};
-				obj[prefix + "_key"] = key;
-				obj[prefix + "_data"] = object[key];
-				ret += this.renderContent( object[ key ], obj);
-			}
-		}
-		return ret;
-	}
-});
 
 })();
 
-MASSGIS.fetchTilesIntoDb = function() {
+MASSGIS.fetchTilesIntoDb = function () {
 	var tilesToFetch = [];
 
 	var dummyTileClass = OpenLayers.Class(OpenLayers.Tile, {
-		"draw" : function (deferred) {
+		"draw": function (deferred) {
 			//console.log("drawing tile ",this.layer.getURL(this.bounds));
 			tilesToFetch.push(this.layer.getURL(this.bounds));
 		}
@@ -3179,7 +3200,7 @@ MASSGIS.fetchTilesIntoDb = function() {
 	t.tileClass = dummyTileClass;
 	t.setMap(MASSGIS.map);
 	t.fetchResolution = t.resolutions.indexOf(t.map.resolution);
-	t.getServerResolution = function(resolution) {
+	t.getServerResolution = function (resolution) {
 		return this.resolutions[t.fetchResolution];
 	};
 
@@ -3193,23 +3214,23 @@ MASSGIS.fetchTilesIntoDb = function() {
 	t.fetchResolution = MASSGIS.map.getZoom() + 2;
 	t.initGriddedTiles(MASSGIS.map.getExtent());
 
-//	t.fetchResolution = MASSGIS.map.getZoom() + 3;
-//	t.initGriddedTiles(MASSGIS.map.getExtent());
+	//	t.fetchResolution = MASSGIS.map.getZoom() + 3;
+	//	t.initGriddedTiles(MASSGIS.map.getExtent());
 
-	MASSGIS.showModalMessage('Fetching Map Tiles for Offline Use (this may take several minutes)','true');
-	window.setTimeout(function() {
+	MASSGIS.showModalMessage('Fetching Map Tiles for Offline Use (this may take several minutes)', 'true');
+	window.setTimeout(function () {
 		$.ajax({
-			type			: 'POST'
-			,url			: 'tiles.php'
-			,data			: JSON.stringify(tilesToFetch)
-			,async			: false
-			,contentType	: "application/json"
-		}).done(function(tiles) {
-			var tileDb = openDatabase('tiledb','1.0','tiledb',1 * 1024 * 1024);
-			tileDb.transaction(function(tx) {
+			type: 'POST'
+			, url: 'tiles.php'
+			, data: JSON.stringify(tilesToFetch)
+			, async: false
+			, contentType: "application/json"
+		}).done(function (tiles) {
+			var tileDb = openDatabase('tiledb', '1.0', 'tiledb', 1 * 1024 * 1024);
+			tileDb.transaction(function (tx) {
 				tx.executeSql('create table if not exists osm (url text unique,uri text)');
 				for (uri in tiles) {
-					tx.executeSql("delete from osm where url = '" + uri + "'" );
+					tx.executeSql("delete from osm where url = '" + uri + "'");
 					tx.executeSql("insert into osm values ('" + uri + "','" + tiles[uri] + "')");
 				}
 				MASSGIS.loadCachedTiles();
@@ -3220,36 +3241,36 @@ MASSGIS.fetchTilesIntoDb = function() {
 };
 
 MASSGIS.dummyTile = OpenLayers.Class(OpenLayers.Tile, {
-	"draw" : function (deferred) {
-		console.log("drawing tile ",this.layer.getURL(tile.bounds));
+	"draw": function (deferred) {
+		console.log("drawing tile ", this.layer.getURL(tile.bounds));
 	}
 });
 
-MASSGIS.generateTXId = function() {
+MASSGIS.generateTXId = function () {
 	var txId = Math.round(Math.random() * 1000000000);
 	return txId;
 };
 
-MASSGIS.showModalMessage = function(msg) {
-	$('.modalWindow').css('display','block');
-	$.mobile.showPageLoadingMsg('b',msg,true);
+MASSGIS.showModalMessage = function (msg) {
+	$('.modalWindow').css('display', 'block');
+	$.mobile.showPageLoadingMsg('b', msg, true);
 };
 
-MASSGIS.hideModalMessage = function() {
-	$(".modalWindow").css('display','none');
+MASSGIS.hideModalMessage = function () {
+	$(".modalWindow").css('display', 'none');
 	$.mobile.hidePageLoadingMsg();
 };
 
 MASSGIS.offsetLimit = 20;
-$(document).ready(function() {
-//alert("'by query' tab scroling v 2.5 enabled");
+$(document).ready(function () {
+	//alert("'by query' tab scroling v 2.5 enabled");
 	var startPos, scrollStart;
-	$('#addr_query ul').on('touchmove', function(evt, ui) {
+	$('#addr_query ul').on('touchmove', function (evt, ui) {
 		if (scrollStart === false) {
 			scrollStart = evt.originalEvent.layerY;
 		}
 		var offset = scrollStart - evt.originalEvent.layerY;
-		console.log("touchmove",evt.originalEvent.layerY,startPos, scrollStart, offset);
+		console.log("touchmove", evt.originalEvent.layerY, startPos, scrollStart, offset);
 		if (offset !== 0) {
 			if (/Android/.test(navigator.userAgent)) {
 				offset = offset * -4;
@@ -3261,12 +3282,12 @@ $(document).ready(function() {
 			scrollStart = false;
 		}
 	});
-	$('#addr_query ul').on('touchstart', function(evt, ui) {
-		console.log("touchstart",evt);
+	$('#addr_query ul').on('touchstart', function (evt, ui) {
+		console.log("touchstart", evt);
 		startPos = $('#addr_query_res').scrollTop();
 		scrollStart = false;
 	});
-	$('#addr_query ul').on('touchend', function(evt, ui) {
-		console.log("touchend",evt);
+	$('#addr_query ul').on('touchend', function (evt, ui) {
+		console.log("touchend", evt);
 	});
 });


### PR DESCRIPTION
1. Adds a warning message when adding a new *part* to a multi-part point.
Message shows:
![image](https://user-images.githubusercontent.com/1263522/57646877-a0cbe180-758f-11e9-902c-48b594db4461.png)

1. Enables multiple selected addresses in the upper-right box to be deleted in bulk.  Select the list of addresses you want to delete, then click "delete".  A confirmation will appear indicating you're deleting *all* selected addresses:
![image](https://user-images.githubusercontent.com/1263522/57647004-ed172180-758f-11e9-93b9-27c901096d83.png)
note: If you click on a "non-yellow" (non-selected) address delete point, then you do *not* delete all selected rather, just the point that was tapped (the old behavior)